### PR TITLE
[Fix] #2: Passwort-vergessen-Link im Login

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import NewPost from './pages/NewPost'
 import Research from './pages/Research'
 import PaperDetail from './pages/PaperDetail'
 import Login from './pages/Login'
+import ForgotPassword from './pages/ForgotPassword'
 import Register from './pages/Register'
 import Profile from './pages/Profile'
 import Hypotheses from './pages/Hypotheses'
@@ -45,6 +46,7 @@ export default function App() {
             <Route path="research" element={<Research />} />
             <Route path="research/:paperId" element={<PaperDetail />} />
             <Route path="login" element={<Login />} />
+            <Route path="passwort-vergessen" element={<ForgotPassword />} />
             <Route path="register" element={<Register />} />
             <Route path="impressum" element={<Imprint />} />
             <Route path="datenschutz" element={<PrivacyPolicy />} />

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -5,6 +5,7 @@ import {
   createUserWithEmailAndPassword,
   signOut,
   sendEmailVerification,
+  sendPasswordResetEmail,
   updateProfile,
   type User,
 } from 'firebase/auth'
@@ -25,6 +26,7 @@ interface AuthContextType {
   register: (payload: RegisterPayload) => Promise<void>
   logout: () => Promise<void>
   resendVerificationEmail: () => Promise<void>
+  resetPassword: (email: string) => Promise<void>
 }
 
 const AuthContext = createContext<AuthContextType | null>(null)
@@ -68,6 +70,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     await signOut(auth)
   }
 
+  async function resetPassword(email: string) {
+    await sendPasswordResetEmail(auth, email)
+  }
+
   async function resendVerificationEmail() {
     if (!auth.currentUser) {
       throw new Error('No authenticated user available.')
@@ -77,7 +83,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }
 
   return (
-    <AuthContext.Provider value={{ user, loading, login, register, logout, resendVerificationEmail }}>
+    <AuthContext.Provider value={{ user, loading, login, register, logout, resendVerificationEmail, resetPassword }}>
       {children}
     </AuthContext.Provider>
   )

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -122,7 +122,13 @@
     "error_invalid_credentials": "E-Mail oder Passwort stimmt nicht.",
     "error_email_in_use": "Diese E-Mail-Adresse ist bereits registriert.",
     "error_password_mismatch": "Die Passwörter stimmen nicht überein.",
-    "error_generic": "Etwas ist schiefgelaufen. Bitte versuche es noch einmal."
+    "error_generic": "Etwas ist schiefgelaufen. Bitte versuche es noch einmal.",
+    "forgot_password_link": "Passwort vergessen?",
+    "forgot_password_title": "Passwort zurücksetzen",
+    "forgot_password_description": "Gib deine E-Mail-Adresse ein. Wir schicken dir einen Link zum Zurücksetzen deines Passworts.",
+    "forgot_password_button": "Reset-Link senden",
+    "forgot_password_success": "Falls ein Konto mit dieser E-Mail-Adresse existiert, hast du in Kürze eine E-Mail mit einem Reset-Link erhalten. Bitte prüfe auch deinen Spam-Ordner.",
+    "back_to_login": "Zurück zur Anmeldung"
   },
   "profile": {
     "title": "Mein Profil",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -122,7 +122,13 @@
     "error_invalid_credentials": "Email or password is incorrect.",
     "error_email_in_use": "This email address is already registered.",
     "error_password_mismatch": "The passwords do not match.",
-    "error_generic": "Something went wrong. Please try again."
+    "error_generic": "Something went wrong. Please try again.",
+    "forgot_password_link": "Forgot password?",
+    "forgot_password_title": "Reset password",
+    "forgot_password_description": "Enter your email address and we will send you a link to reset your password.",
+    "forgot_password_button": "Send reset link",
+    "forgot_password_success": "If an account with this email address exists, you will receive an email with a reset link shortly. Please also check your spam folder.",
+    "back_to_login": "Back to login"
   },
   "profile": {
     "title": "My Profile",

--- a/src/pages/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword.tsx
@@ -1,0 +1,100 @@
+import { useState, type FormEvent } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { FirebaseError } from 'firebase/app'
+import { useAuth } from '../contexts/AuthContext'
+import { usePageMeta } from '../hooks/usePageMeta'
+
+export default function ForgotPassword() {
+  const { t } = useTranslation()
+  const { resetPassword } = useAuth()
+  const [email, setEmail] = useState('')
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState(false)
+  const [loading, setLoading] = useState(false)
+
+  usePageMeta({
+    title: `${t('auth.forgot_password_title')} | SpondylAtlas`,
+    robots: 'noindex, nofollow',
+  })
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault()
+    setError('')
+    setLoading(true)
+
+    try {
+      await resetPassword(email)
+      setSuccess(true)
+    } catch (submitError) {
+      if (
+        submitError instanceof FirebaseError &&
+        submitError.code === 'auth/user-not-found'
+      ) {
+        // Aus Sicherheitsgründen trotzdem Erfolgsmeldung anzeigen
+        setSuccess(true)
+      } else {
+        setError(t('auth.error_generic'))
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-md px-4 py-16">
+      <h1 className="text-center text-2xl font-bold text-gray-900">
+        {t('auth.forgot_password_title')}
+      </h1>
+      <p className="mt-3 text-center text-sm leading-6 text-stone-600">
+        {t('auth.forgot_password_description')}
+      </p>
+
+      {error && (
+        <div className="mt-4 rounded-lg bg-red-50 p-3 text-sm text-red-700">{error}</div>
+      )}
+
+      {success ? (
+        <div className="mt-8 rounded-lg bg-green-50 p-4 text-sm text-green-800">
+          <p>{t('auth.forgot_password_success')}</p>
+          <p className="mt-3">
+            <Link to="/login" className="font-medium text-primary-600 hover:underline">
+              {t('auth.back_to_login')}
+            </Link>
+          </p>
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="mt-8 space-y-4">
+          <div>
+            <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+              {t('auth.email')}
+            </label>
+            <input
+              id="email"
+              type="email"
+              required
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              className="mt-1 w-full rounded-lg border border-gray-300 px-4 py-2.5 text-gray-900 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/20"
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full rounded-lg bg-primary-600 py-2.5 font-medium text-white transition-colors hover:bg-primary-700 disabled:opacity-50"
+          >
+            {t('auth.forgot_password_button')}
+          </button>
+        </form>
+      )}
+
+      {!success && (
+        <p className="mt-6 text-center text-sm text-gray-600">
+          <Link to="/login" className="font-medium text-primary-600 hover:underline">
+            {t('auth.back_to_login')}
+          </Link>
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -79,6 +79,11 @@ export default function Login() {
             className="mt-1 w-full rounded-lg border border-gray-300 px-4 py-2.5 text-gray-900 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/20"
           />
         </div>
+        <div className="text-right">
+          <Link to="/passwort-vergessen" className="text-sm font-medium text-primary-600 hover:underline">
+            {t('auth.forgot_password_link')}
+          </Link>
+        </div>
         <button
           type="submit"
           disabled={loading}


### PR DESCRIPTION
Fixes #2

## Änderungen
- `AuthContext`: `sendPasswordResetEmail` importiert, `resetPassword(email)`-Funktion hinzugefügt und im Context-Wert exponiert
- `Login.tsx`: "Passwort vergessen?"-Link unterhalb des Passwort-Felds ergänzt (Route: `/passwort-vergessen`)
- `ForgotPassword.tsx`: Neue Seite mit E-Mail-Formular, Firebase-Reset-Mail-Versand und Erfolgsmeldung (Sicherheit: kein User-Enumeration-Leak)
- `App.tsx`: Route `/passwort-vergessen` registriert
- i18n: Alle neuen Texte auf DE und EN gepflegt (echte Umlaute)

## Test
- Lint und TypeScript-Check bestehen (main-Repo)
- Reset-Flow: E-Mail eingeben → Erfolgsanzeige ohne User-Enumeration
- Zurück-zum-Login-Link auf Erfolgsseite vorhanden