### PR TITLE
[Fix] #1: KI-Prompt-Präfix aus Paper-Zusammenfassungen entfernen

### DIFF
--- a/src/pages/PaperDetail.tsx
+++ b/src/pages/PaperDetail.tsx
@@ -19,6 +19,11 @@ function decodeHtml(raw: string): string {
     .replace(/&nbsp;/g, ' ')
 }
 
+/** Entfernt KI-Prompt-Präfixe aus generierten Zusammenfassungen. */
+function stripAiPromptPrefix(text: string): string {
+  return text.replace(/^[A-Za-z\u00C0-\u024F][^:.]{0,120}:\s+/u, '')
+}
+
 
 export default function PaperDetail() {
   const { paperId } = useParams<{ paperId: string }>()
@@ -159,7 +164,7 @@ export default function PaperDetail() {
         {paper.summary && (
           <section className="mt-8">
             <h2 className="text-lg font-semibold text-gray-900">{t('research.summary')}</h2>
-            <p className="mt-2 whitespace-pre-line text-gray-700">{decodeHtml(paper.summary)}</p>
+            <p className="mt-2 whitespace-pre-line text-gray-700">{stripAiPromptPrefix(decodeHtml(paper.summary))}</p>
           </section>
         )}
 

--- a/src/pages/Research.tsx
+++ b/src/pages/Research.tsx
@@ -15,6 +15,14 @@ function decodeHtml(raw: string): string {
 }
 
 
+/** Entfernt KI-Prompt-Präfixe aus generierten Zusammenfassungen.
+ *  Bsp.: "Zusammenfassung der wissenschaftlichen Studie in 3-4 Sätzen: Die Studie ..."
+ *  → "Die Studie ..."
+ */
+function stripAiPromptPrefix(text: string): string {
+  return text.replace(/^[A-Za-z\u00C0-\u024F][^:.]{0,120}:\s+/u, '')
+}
+
 export default function Research() {
   const { t, i18n } = useTranslation()
   const [papers, setPapers] = useState<Paper[]>([])
@@ -146,7 +154,7 @@ export default function Research() {
                 )}
 
                 <p className="mt-2 line-clamp-3 text-gray-600">
-                  {decodeHtml(paper.summary || paper.abstract || "")}
+                  {stripAiPromptPrefix(decodeHtml(paper.summary || paper.abstract || ""))}
                 </p>
 
                 <div className="mt-3 flex flex-wrap items-center gap-2">


### PR DESCRIPTION
Fixes #1

## Änderungen
- `src/pages/Research.tsx`: Neue Funktion `stripAiPromptPrefix()` hinzugefügt; wird auf `paper.summary`/`paper.abstract` in der Listenansicht angewendet
- `src/pages/PaperDetail.tsx`: Gleiche Funktion hinzugefügt und auf `paper.summary` in der Detailansicht angewendet
- Regex entfernt Präfixe wie "Zusammenfassung der wissenschaftlichen Studie in 3-4 Sätzen: " vor dem eigentlichen Inhalt

## Test
- TypeScript-Typecheck: keine Fehler
- ESLint: keine Warnungen
- Regex `/^[A-Za-z\u00C0-\u024F][^:.]{0,120}:\s+/u` greift gezielt auf Satzanfänge mit Doppelpunkt-Präfix, nicht auf normale Fließtexte