### PR TITLE
[Fix] #5: Veraltete Modell-Strings aktualisieren (claude-3-haiku → claude-3-5-haiku-latest)

### DIFF
--- a/agents/evidence-grader.ts
+++ b/agents/evidence-grader.ts
@@ -18,7 +18,7 @@ type EvidenceLevel = "1a" | "1b" | "2a" | "2b" | "3" | "4" | "5";
 
 async function gradeEvidence(title: string, abstract: string) {
   const msg = await anthropic.messages.create({
-    model: "claude-3-haiku-20240307",
+    model: "claude-3-5-haiku-latest",
     max_tokens: 512,
     messages: [{
       role: "user",

--- a/agents/forum-moderator.ts
+++ b/agents/forum-moderator.ts
@@ -68,7 +68,7 @@ Antworte NUR mit diesem JSON-Format (kein Markdown, kein Text davor/danach):
 {"decision":"approve|reject|escalate","reason":"Kurze Begründung auf Deutsch (max 100 Zeichen)"}`;
 
   const response = await anthropic.messages.create({
-    model: "claude-3-haiku-20240307",
+    model: "claude-3-5-haiku-latest",
     max_tokens: 200,
     messages: [{ role: "user", content: prompt }],
   });

--- a/agents/paper-search-agent.ts
+++ b/agents/paper-search-agent.ts
@@ -317,7 +317,7 @@ async function generateSummary(
   }
 
   const message = await client.messages.create({
-    model: "claude-3-haiku-20240307",
+    model: "claude-3-5-haiku-latest",
     max_tokens: 300,
     messages: [
       {

--- a/agents/summary-writer.ts
+++ b/agents/summary-writer.ts
@@ -16,7 +16,7 @@ const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
 async function writePatientSummary(title: string, abstract: string, evidenceLevel: string) {
   const msg = await anthropic.messages.create({
-    model: "claude-3-haiku-20240307",
+    model: "claude-3-5-haiku-latest",
     max_tokens: 800,
     messages: [{
       role: "user",

--- a/agents/trial-tracker.ts
+++ b/agents/trial-tracker.ts
@@ -40,7 +40,7 @@ async function fetchTrials(): Promise<any[]> {
 
 async function summarizeTrial(title: string, description: string): Promise<string> {
   const msg = await anthropic.messages.create({
-    model: "claude-3-haiku-20240307",
+    model: "claude-3-5-haiku-latest",
     max_tokens: 200,
     messages: [{
       role: "user",


### PR DESCRIPTION
Fixes #5

## Änderungen
- `evidence-grader.ts`: claude-3-haiku-20240307 → claude-3-5-haiku-latest
- `forum-moderator.ts`: claude-3-haiku-20240307 → claude-3-5-haiku-latest
- `paper-search-agent.ts`: claude-3-haiku-20240307 → claude-3-5-haiku-latest
- `summary-writer.ts`: claude-3-haiku-20240307 → claude-3-5-haiku-latest
- `trial-tracker.ts`: claude-3-haiku-20240307 → claude-3-5-haiku-latest

**Hinweis:** `hypothesis-generator.ts` und `hypothesis-critic.ts` wurden bereits in einem früheren Commit auf `claude-opus-4-5` umgestellt und sind nicht betroffen.

## Hintergrund
Die Hypothesis-Generator-Fehler waren auf veraltete Modell-IDs zurückzuführen. Dieser PR aktualisiert alle verbleibenden Agenten, die noch `claude-3-haiku-20240307` verwendeten, auf `claude-3-5-haiku-latest` (versionsstabiler Alias).

## Test
- TypeScript-Check: keine Fehler
- Modell-Strings entsprechen den aktuell verfügbaren Anthropic-Modellen