### PR TITLE
[Fix] #8: Firebase Hosting Cache-Control für index.html und Assets

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -4,6 +4,20 @@
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
     "headers": [
       {
+        "source": "/index.html",
+        "headers": [
+          { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" },
+          { "key": "Pragma", "value": "no-cache" },
+          { "key": "Expires", "value": "0" }
+        ]
+      },
+      {
+        "source": "/assets/**",
+        "headers": [
+          { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+        ]
+      },
+      {
         "source": "**",
         "headers": [
           { "key": "X-Content-Type-Options", "value": "nosniff" },


### PR DESCRIPTION
Fixes #8

## Problem
Firebase Hosting liefert für `/assets/*.js` und `/assets/*.css` den MIME-Typ `text/html`, wenn die Asset-Datei nicht existiert (z.B. nach einem neuen Deploy mit neuen Hashes). Die `**`-Rewrite-Regel greift auf 404-Anfragen und liefert `index.html` zurück — mit falschem MIME-Typ.

**Root Cause:** Browser cachen die `index.html` und laden nach einem neuen Deploy veraltete Asset-Hashes. Firebase antwortet auf nicht-existierende Assets mit `index.html` (Rewrite), was der Browser wegen Strict MIME Type Checking ablehnt.

## Änderungen
- `firebase.json`: `Cache-Control: no-cache, no-store, must-revalidate` für `/index.html` — Browser holt immer die aktuellste Version mit korrekten Asset-Hashes
- `firebase.json`: `Cache-Control: public, max-age=31536000, immutable` für `/assets/**` — Assets sind content-hashed (Vite), können daher dauerhaft gecacht werden

## Warum das funktioniert
- Browser lädt immer die neueste `index.html` → korrekte Asset-Hashes
- Assets mit korrekten Hashes existieren auf dem Server → kein Fallback auf Rewrite → kein falscher MIME-Typ
- `/register` direkt aufrufen: Rewrite liefert `index.html` (korrekt für SPA), dann werden Assets mit aktuellen Hashes geladen ✅

## Test
- Direkt zu `/register` navigieren (Inkognito) → Registrierungsformular wird angezeigt
- Nach neuem Deploy: Browser holt neue `index.html` → keine veralteten Asset-Hashes im Cache