### PR TITLE
[Fix] #4: Hypothesis-Critic und Generator referenzieren Papers per Titel statt ID

### DIFF
--- a/agents/hypothesis-critic.ts
+++ b/agents/hypothesis-critic.ts
@@ -49,7 +49,7 @@ async function critiqueHypothesis(
 ): Promise<CriticResult> {
   const paperContext = papers
     .slice(0, 25)
-    .map((p) => `ID:${p.id} [${p.evidenceLevel ?? "?"}]\n${p.title}\n${(p.summary || p.abstract).slice(0, 350)}`)
+    .map((p) => `ID:${p.id} [${p.evidenceLevel ?? "?"}]\nTitel: ${p.title}\n${(p.summary || p.abstract).slice(0, 350)}`)
     .join("\n\n---\n\n");
 
   const prompt = `Du bist ein kritischer Wissenschaftler für axiale Spondyloarthritis (Morbus Bechterew).
@@ -66,14 +66,19 @@ ${paperContext}
 
 Bewerte streng nach diesen Kategorien:
 
-- **challenged**: Du hast konkrete Gegenbeweise in den Papers gefunden. Nenne Paper-IDs und Argumente.
+- **challenged**: Du hast konkrete Gegenbeweise in den Papers gefunden. Nenne Paper-Titel (nicht IDs) und Argumente.
 - **needs_research**: Die vorhandenen Papers sind unvollständig. Definiere einen konkreten Rechercheauftrag.
 - **open**: Keine Widerlegung möglich, aber auch keine volle Bestätigung. Hypothese bleibt offen.
+
+WICHTIG für das "argument"-Feld:
+- Nenne Papers immer beim vollen Titel (z.B. 'Die Studie „Sex differences in clinical characteristics..." zeigt...')
+- Verwende KEINE rohen IDs oder Nummern wie "Paper rtfu3Z..." oder "Paper 1"
+- Schreibe für Endnutzer verständlich
 
 Antworte NUR mit diesem JSON (kein Markdown):
 {
   "verdict": "challenged|open|needs_research",
-  "argument": "Deine Begründung auf Deutsch (3-5 Sätze)",
+  "argument": "Deine Begründung auf Deutsch (3-5 Sätze), Paper-Referenzen nur per Titel",
   "researchQuery": "Nur bei needs_research: Konkreter Suchauftrag für weitere Papers (1-2 Sätze)",
   "paperIds": ["ids der relevanten Gegenbeweise, leer wenn keine"]
 }`;

--- a/agents/hypothesis-generator.ts
+++ b/agents/hypothesis-generator.ts
@@ -79,7 +79,7 @@ Anforderungen:
 - Hypothesen müssen NEU und noch NICHT explizit in den Papers bewiesen sein
 - Sie sollen testbare Zusammenhänge zwischen Faktoren beschreiben
 - Formuliere auf Deutsch, klar und präzise
-- Beziehe dich konkret auf die Paper-IDs als Basis
+- Beziehe dich konkret auf Paper-Titel als Basis (keine rohen IDs verwenden)
 
 Studien:
 ${paperSummaries}
@@ -89,7 +89,7 @@ Antworte NUR mit diesem JSON-Array (kein Markdown):
   {
     "title": "Kurzer Hypothesentitel (max 80 Zeichen)",
     "description": "Vollständige Hypothese in 2-3 Sätzen",
-    "rationale": "Warum legen die Paper das nahe? Welche Paper-IDs stützen das?",
+    "rationale": "Warum legen die Paper das nahe? Nenne die relevanten Paper beim Titel (keine IDs oder Nummern wie 'Paper 1')",
     "paperIds": ["id1", "id2"]
   }
 ]`;


### PR DESCRIPTION
Fixes #4

## Änderungen

**agents/hypothesis-critic.ts**
- Paper-Kontext-Format: Fügt explizites Titel-Prefix hinzu
- Prompt: Anweisung geändert von Nenne Paper-IDs zu Nenne Paper-Titel (nicht IDs)
- Neuer WICHTIG-Block: verbietet explizit rohe IDs oder numerische Referenzen
- Zielformat: Die Studie XY zeigt...

**agents/hypothesis-generator.ts**
- Prompt: Beziehe dich auf Paper-Titel statt Paper-IDs
- Rationale-Beispiel: Verhindert numerische Index-Referenzen wie Paper 13

Die paperIds-Felder (strukturierte Daten) bleiben unverändert.

## Test
- TypeScript-Compilation: npx tsc -b --noEmit ohne Fehler
- Agents ziehen neuen Prompt beim nächsten Run automatisch