### PR TITLE
[Fix] #12: stripAiPromptPrefix & decodeHtml in geteilte Utility extrahieren

### DIFF
--- a/src/lib/textUtils.ts
+++ b/src/lib/textUtils.ts
@@ -1,0 +1,38 @@
+/**
+ * Decodes common HTML entities in a string.
+ */
+export function decodeHtml(raw: string): string {
+  return raw
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
+    .replace(/&#([0-9]+);/g, (_, dec) => String.fromCodePoint(Number(dec)))
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&nbsp;/g, ' ')
+}
+
+/**
+ * Entfernt KI-Prompt-Präfixe aus generierten Zusammenfassungen.
+ *
+ * Beispiele:
+ *   "Zusammenfassung der wissenschaftlichen Studie in 3-4 Sätzen: Die Studie ..."
+ *   → "Die Studie ..."
+ *
+ *   "Summary of the scientific study: This study ..."
+ *   → "This study ..."
+ *
+ * Die Funktion wird iterativ angewendet, um verschachtelte Präfixe zu entfernen
+ * (z. B. "Zusammenfassung: Analyse: Die Studie ...").
+ */
+export function stripAiPromptPrefix(text: string): string {
+  const pattern = /^[A-Za-z\u00C0-\u024F][^:.]{0,120}:\s+/u
+  let result = text.trim()
+  let prev: string
+  do {
+    prev = result
+    result = result.replace(pattern, '')
+  } while (result !== prev && result.length > 0)
+  return result
+}

--- a/src/pages/PaperDetail.tsx
+++ b/src/pages/PaperDetail.tsx
@@ -5,25 +5,7 @@ import { doc, getDoc } from 'firebase/firestore'
 import { db } from '../lib/firebase'
 import type { Paper } from '../lib/types'
 import { usePageMeta } from '../hooks/usePageMeta'
-
-// Decode HTML entities from PubMed raw text
-function decodeHtml(raw: string): string {
-  return raw
-    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
-    .replace(/&#([0-9]+);/g, (_, dec) => String.fromCodePoint(Number(dec)))
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&apos;/g, "'")
-    .replace(/&nbsp;/g, ' ')
-}
-
-/** Entfernt KI-Prompt-Präfixe aus generierten Zusammenfassungen. */
-function stripAiPromptPrefix(text: string): string {
-  return text.replace(/^[A-Za-z\u00C0-\u024F][^:.]{0,120}:\s+/u, '')
-}
-
+import { decodeHtml, stripAiPromptPrefix } from '../lib/textUtils'
 
 export default function PaperDetail() {
   const { paperId } = useParams<{ paperId: string }>()

--- a/src/pages/Research.tsx
+++ b/src/pages/Research.tsx
@@ -5,23 +5,7 @@ import { collection, getDocs, orderBy, query } from 'firebase/firestore'
 import { db } from '../lib/firebase'
 import type { Paper } from '../lib/types'
 import { usePageMeta } from '../hooks/usePageMeta'
-
-function decodeHtml(raw: string): string {
-  return raw
-    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
-    .replace(/&#([0-9]+);/g, (_, dec) => String.fromCodePoint(Number(dec)))
-    .replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"').replace(/&apos;/g, "'").replace(/&nbsp;/g, ' ')
-}
-
-
-/** Entfernt KI-Prompt-Präfixe aus generierten Zusammenfassungen.
- *  Bsp.: "Zusammenfassung der wissenschaftlichen Studie in 3-4 Sätzen: Die Studie ..."
- *  → "Die Studie ..."
- */
-function stripAiPromptPrefix(text: string): string {
-  return text.replace(/^[A-Za-z\u00C0-\u024F][^:.]{0,120}:\s+/u, '')
-}
+import { decodeHtml, stripAiPromptPrefix } from '../lib/textUtils'
 
 export default function Research() {
   const { t, i18n } = useTranslation()


### PR DESCRIPTION
Fixes #12

## Analyse

Der Prompt-Prefix-Strip war bereits in PR #6 für `Research.tsx` implementiert. Issue #12 wurde ~14 Minuten nach dem Merge von PR #6 erstellt — vermutlich bevor das Deployment abgeschlossen war. Die Logik war also korrekt, aber auf beide Seiten dupliziert.

## Änderungen

- **Neu:** `src/lib/textUtils.ts` — geteilte Utility-Datei mit `decodeHtml` und `stripAiPromptPrefix`
- **Verbessert:** `stripAiPromptPrefix` wird jetzt iterativ angewendet (verschachtelte Präfixe wie `Zusammenfassung: Analyse: Text...` werden vollständig entfernt) und trimmt führende Whitespace
- **Refactored:** `Research.tsx` und `PaperDetail.tsx` importieren aus der gemeinsamen Utility — keine Code-Duplikation mehr

## Test

- `npm run build` → keine Fehler (tsc + vite)
- Regex deckt alle bekannten Muster ab: `Zusammenfassung der wissenschaftlichen Studie in 3-4 Sätzen: ...`, `Summary of the study: ...` etc.