### PR TITLE
[Fix] #14: Navigation-Links 'Hypothesen' und 'Arena' per i18n übersetzen

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -45,8 +45,8 @@ export default function Navbar() {
     { to: '/', label: t('nav.home'), end: true },
     { to: '/research', label: t('nav.research') },
     { to: '/forum', label: t('nav.forum') },
-    { to: '/hypotheses', label: ' Hypothesen' },
-    { to: '/arena', label: 'Arena' },
+    { to: '/hypotheses', label: t('nav.hypotheses') },
+    { to: '/arena', label: t('nav.arena') },
   ]
 
   return (

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -3,6 +3,8 @@
     "home": "Startseite",
     "forum": "Forum",
     "research": "Forschung",
+    "hypotheses": "Hypothesen",
+    "arena": "Arena",
     "login": "Anmelden",
     "register": "Registrieren",
     "profile": "Profil",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3,6 +3,8 @@
     "home": "Home",
     "forum": "Forum",
     "research": "Research",
+    "hypotheses": "Hypotheses",
+    "arena": "Arena",
     "login": "Sign in",
     "register": "Register",
     "profile": "Profile",


### PR DESCRIPTION
Fixes #14

## Änderungen
- `src/components/Navbar.tsx`: Hardcodierte Labels `' Hypothesen'` und `'Arena'` durch `t('nav.hypotheses')` und `t('nav.arena')` ersetzt
- `src/i18n/locales/de.json`: Neue Keys `nav.hypotheses` ("Hypothesen") und `nav.arena` ("Arena") hinzugefügt
- `src/i18n/locales/en.json`: Neue Keys `nav.hypotheses` ("Hypotheses") und `nav.arena` ("Arena") hinzugefügt

## Test
- ESLint: 0 Fehler, 0 Warnungen (nur .tsx geprüft)
- TypeScript: keine Fehler
- Bei EN-Umschaltung werden jetzt alle Nav-Links korrekt übersetzt