### PR TITLE
[Fix] #19: no-cache Headers für alle SPA-Routen (Arena-Footer-Regression)

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,30 +1,78 @@
 {
   "hosting": {
     "public": "dist",
-    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
     "headers": [
       {
         "source": "/index.html",
         "headers": [
-          { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" },
-          { "key": "Pragma", "value": "no-cache" },
-          { "key": "Expires", "value": "0" }
+          {
+            "key": "Cache-Control",
+            "value": "no-cache, no-store, must-revalidate"
+          },
+          {
+            "key": "Pragma",
+            "value": "no-cache"
+          },
+          {
+            "key": "Expires",
+            "value": "0"
+          }
+        ]
+      },
+      {
+        "source": "!/assets/**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache, no-store, must-revalidate"
+          },
+          {
+            "key": "Pragma",
+            "value": "no-cache"
+          },
+          {
+            "key": "Expires",
+            "value": "0"
+          }
         ]
       },
       {
         "source": "/assets/**",
         "headers": [
-          { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=31536000, immutable"
+          }
         ]
       },
       {
         "source": "**",
         "headers": [
-          { "key": "X-Content-Type-Options", "value": "nosniff" },
-          { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-          { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
-          { "key": "X-Frame-Options", "value": "DENY" },
-          { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
+          {
+            "key": "X-Content-Type-Options",
+            "value": "nosniff"
+          },
+          {
+            "key": "Referrer-Policy",
+            "value": "strict-origin-when-cross-origin"
+          },
+          {
+            "key": "Permissions-Policy",
+            "value": "camera=(), microphone=(), geolocation=()"
+          },
+          {
+            "key": "X-Frame-Options",
+            "value": "DENY"
+          },
+          {
+            "key": "Cross-Origin-Opener-Policy",
+            "value": "same-origin"
+          },
           {
             "key": "Content-Security-Policy",
             "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com https://firestore.googleapis.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
@@ -33,27 +81,57 @@
       },
       {
         "source": "/forum",
-        "headers": [{ "key": "X-Robots-Tag", "value": "noindex, nofollow, noarchive" }]
+        "headers": [
+          {
+            "key": "X-Robots-Tag",
+            "value": "noindex, nofollow, noarchive"
+          }
+        ]
       },
       {
         "source": "/forum/**",
-        "headers": [{ "key": "X-Robots-Tag", "value": "noindex, nofollow, noarchive" }]
+        "headers": [
+          {
+            "key": "X-Robots-Tag",
+            "value": "noindex, nofollow, noarchive"
+          }
+        ]
       },
       {
         "source": "/profile",
-        "headers": [{ "key": "X-Robots-Tag", "value": "noindex, nofollow, noarchive" }]
+        "headers": [
+          {
+            "key": "X-Robots-Tag",
+            "value": "noindex, nofollow, noarchive"
+          }
+        ]
       },
       {
         "source": "/profile/**",
-        "headers": [{ "key": "X-Robots-Tag", "value": "noindex, nofollow, noarchive" }]
+        "headers": [
+          {
+            "key": "X-Robots-Tag",
+            "value": "noindex, nofollow, noarchive"
+          }
+        ]
       },
       {
         "source": "/login",
-        "headers": [{ "key": "X-Robots-Tag", "value": "noindex, nofollow, noarchive" }]
+        "headers": [
+          {
+            "key": "X-Robots-Tag",
+            "value": "noindex, nofollow, noarchive"
+          }
+        ]
       },
       {
         "source": "/register",
-        "headers": [{ "key": "X-Robots-Tag", "value": "noindex, nofollow, noarchive" }]
+        "headers": [
+          {
+            "key": "X-Robots-Tag",
+            "value": "noindex, nofollow, noarchive"
+          }
+        ]
       }
     ],
     "rewrites": [


### PR DESCRIPTION
Fixes #19

## Ursache

`firebase.json` setzte `Cache-Control: no-cache` bisher **nur** für den direkten Pfad `/index.html`.

Alle SPA-Routen (z. B. `/arena`, `/hypotheses`, ...) werden über den Rewrite-Catch-All `"**" → /index.html` bedient. Dabei greifen die Header-Regeln anhand des **Anfragepfades**, nicht des Rewrite-Ziels — d. h. `/arena` erhielt **keine** Cache-Control-Header und wurde von der Firebase CDN mit dem alten Build gecacht (vor Fix #16).

Deshalb zeigte der Footer auf `/arena` nur 3 Links (ohne Hypothesen + Arena), während andere direkt als HTML zugängliche Pfade den neuen Build lieferten.

## Änderungen

- `firebase.json`: Neue Header-Regel `!/assets/**` mit `no-cache, no-store, must-revalidate` — gilt für alle Pfade außer Assets (die weiterhin mit `max-age=31536000, immutable` gecacht werden)

## Test

- Alle SPA-Routen erhalten nun bei jedem Abruf frische Responses vom CDN
- `/assets/**` bleibt unverändert mit langem Cache (Inhalts-Hash ändert sich bei Rebuilds)