### PR TITLE
[Fix] #18: Critic-Agent — keine rohen Firestore-IDs mehr im Argument-Text

### DIFF
--- a/agents/hypothesis-critic.ts
+++ b/agents/hypothesis-critic.ts
@@ -47,9 +47,15 @@ async function critiqueHypothesis(
   hypothesis: { id: string; title: string; description: string; rationale: string; paperIds: string[] },
   papers: { id: string; title: string; abstract: string; summary: string; evidenceLevel?: string }[]
 ): Promise<CriticResult> {
-  const paperContext = papers
-    .slice(0, 25)
-    .map((p) => `ID:${p.id} [${p.evidenceLevel ?? "?"}]\nTitel: ${p.title}\n${(p.summary || p.abstract).slice(0, 350)}`)
+  const slicedPapers = papers.slice(0, 25);
+
+  // Build numbered context — IDs are NOT exposed to the LLM to prevent raw-ID leakage in argument text.
+  // After parsing, we map 1-based paper numbers back to real Firestore IDs.
+  const paperContext = slicedPapers
+    .map(
+      (p, i) =>
+        `[${i + 1}] Evidenz: ${p.evidenceLevel ?? "?"}\nTitel: ${p.title}\n${(p.summary || p.abstract).slice(0, 350)}`
+    )
     .join("\n\n---\n\n");
 
   const prompt = `Du bist ein kritischer Wissenschaftler für axiale Spondyloarthritis (Morbus Bechterew).
@@ -61,26 +67,29 @@ Titel: "${hypothesis.title}"
 Beschreibung: ${hypothesis.description}
 Begründung: ${hypothesis.rationale}
 
-VERFÜGBARE STUDIEN:
+VERFÜGBARE STUDIEN (nummeriert [1]–[${slicedPapers.length}]):
 ${paperContext}
 
 Bewerte streng nach diesen Kategorien:
 
-- **challenged**: Du hast konkrete Gegenbeweise in den Papers gefunden. Nenne Paper-Titel (nicht IDs) und Argumente.
+- **challenged**: Du hast konkrete Gegenbeweise in den Papers gefunden.
 - **needs_research**: Die vorhandenen Papers sind unvollständig. Definiere einen konkreten Rechercheauftrag.
 - **open**: Keine Widerlegung möglich, aber auch keine volle Bestätigung. Hypothese bleibt offen.
 
 WICHTIG für das "argument"-Feld:
-- Nenne Papers immer beim vollen Titel (z.B. 'Die Studie „Sex differences in clinical characteristics..." zeigt...')
-- Verwende KEINE rohen IDs oder Nummern wie "Paper rtfu3Z..." oder "Paper 1"
-- Schreibe für Endnutzer verständlich
+- Nenne Papers immer beim vollen Titel (z.B. 'Die Studie "Sex differences in clinical characteristics..." zeigt...')
+- Schreibe für Endnutzer verständlich — KEINE technischen IDs, KEINE Nummern wie "[1]" im Fließtext
+
+WICHTIG für das "paperNumbers"-Feld:
+- Gib die Nummern (1-basiert) der relevanten Papers als Integer-Array an (z.B. [2, 5])
+- Leer-Array wenn keine Papers direkt relevant sind
 
 Antworte NUR mit diesem JSON (kein Markdown):
 {
   "verdict": "challenged|open|needs_research",
-  "argument": "Deine Begründung auf Deutsch (3-5 Sätze), Paper-Referenzen nur per Titel",
+  "argument": "Deine Begründung auf Deutsch (3-5 Sätze), Paper-Referenzen nur per vollem Titel",
   "researchQuery": "Nur bei needs_research: Konkreter Suchauftrag für weitere Papers (1-2 Sätze)",
-  "paperIds": ["ids der relevanten Gegenbeweise, leer wenn keine"]
+  "paperNumbers": [1, 2]
 }`;
 
   const response = await anthropic.messages.create({
@@ -91,13 +100,29 @@ Antworte NUR mit diesem JSON (kein Markdown):
 
   const text = response.content[0].type === "text" ? response.content[0].text.trim() : "{}";
 
+  let parsed: { verdict: CriticVerdict; argument: string; researchQuery?: string; paperNumbers?: number[] };
   try {
-    return JSON.parse(text) as CriticResult;
+    parsed = JSON.parse(text);
   } catch {
     const match = text.match(/\{[\s\S]*\}/);
-    if (match) return JSON.parse(match[0]) as CriticResult;
-    return { verdict: "open", argument: "Parse-Fehler — manuelle Prüfung", paperIds: [] };
+    if (match) {
+      parsed = JSON.parse(match[0]);
+    } else {
+      return { verdict: "open", argument: "Parse-Fehler — manuelle Prüfung", paperIds: [] };
+    }
   }
+
+  // Map 1-based paper numbers back to real Firestore IDs
+  const paperIds = (parsed.paperNumbers ?? [])
+    .filter((n) => typeof n === "number" && n >= 1 && n <= slicedPapers.length)
+    .map((n) => slicedPapers[n - 1].id);
+
+  return {
+    verdict: parsed.verdict,
+    argument: parsed.argument,
+    researchQuery: parsed.researchQuery,
+    paperIds,
+  };
 }
 
 async function main() {


### PR DESCRIPTION
Fixes #18

## Problem
Der Critic-Agent hat rohe Firestore-IDs (z.B. `rtfu3ZjLMHc4VqMR6rLI`) im `criticArgument`-Text ausgegeben, weil der LLM-Kontext die IDs direkt enthielt (`ID:${p.id}`).

## Änderungen

### `agents/hypothesis-critic.ts`
- **Paper-Kontext nummeriert** statt ID-exponiert: Jedes Paper bekommt eine 1-basierte Nummer [1]..[N] — keine IDs im Fließtext-Kontext
- **Neues Feld `paperNumbers`** im JSON-Output: LLM gibt Integer-Array der relevanten Papers zurück statt roher IDs
- **Server-seitiges ID-Mapping**: Nach dem Parsen werden Nummern auf echte Firestore-IDs gemappt (slicedPapers[n-1].id)
- **Prompt-Anweisung verschärft**: Explizit verboten, Nummern wie "[1]" im Fließtext zu verwenden — nur volle Paper-Titel

## Warum dieser Ansatz?
Solange der LLM die rohen IDs sieht, kann er sie trotz Verbots einbauen. Die Lösung ist strukturell: IDs werden dem LLM gar nicht erst exponiert.

## Test
- `npx tsc -b --noEmit` auf src/ — 0 Fehler
- ESLint-Fehler sind alle pre-existing (identisch mit main)
