### PR TITLE
[Fix] #26: Hypothesis Critic JSON-Parse — Steuerzeichen in LLM-Strings escapen

### DIFF
--- a/agents/hypothesis-critic.ts
+++ b/agents/hypothesis-critic.ts
@@ -118,7 +118,19 @@ Antworte NUR mit diesem JSON (kein Markdown):
       try {
         parsed = JSON.parse(match[0]);
       } catch {
-        // fallthrough to safe default
+        // Attempt 3: sanitize literal control chars inside JSON string values and retry
+        // Root cause of "Expected ',' or '}' at position N": LLM writes multi-sentence
+        // text with bare newlines inside a JSON string value, which is invalid per spec.
+        try {
+          const sanitized = match[0].replace(
+            /"((?:[^"\\]|\\.)*)"/gs,
+            (_m: string, inner: string) =>
+              `"${inner.replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t")}"`
+          );
+          parsed = JSON.parse(sanitized);
+        } catch {
+          // fallthrough to safe default
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #26

## Root Cause

Der JSON-Parse-Fehler `Expected ',' or '}' after property value at position 248` tritt auf, weil das LLM mehrzeiligen Text mit **literalen Zeilenumbrüchen** direkt in JSON-String-Werte schreibt (z.B. im `argument`-Feld). Das ist per JSON-Spec ungültig.

Der Fix aus #22 (Markdown-Code-Fences entfernen + 2. Versuch mit `{...}`-Block-Extraktion) greift nicht in diesem Fall, da das `{...}`-Block korrekt extrahiert wird, aber intern invalid bleibt.

## Änderungen

- `agents/hypothesis-critic.ts`: Neuer **Attempt 3** in der JSON-Parse-Kette:
  - Nach fehlgeschlagenem direktem Parse (Attempt 1) und Block-Extraktion (Attempt 2)
  - Regex ersetzt literal `\n`/`\r`/`\t` **innerhalb JSON-String-Werten** durch ihre escaped Äquivalente (`\\n` etc.)
  - Dann nochmaliger `JSON.parse` Versuch

## Parse-Kette (vollständig)

1. Markdown-Code-Fences entfernen (```json...```)
2. Attempt 1: direkter `JSON.parse`
3. Attempt 2: erstes `{...}`-Block extrahieren + parse
4. **Attempt 3 (neu):** Steuerzeichen in String-Werten sanitizen + parse
5. Fallback: `{ verdict: "open", argument: "Parse-Fehler — manuelle Prüfung nötig" }`

## Test

- TypeScript Build: ✅ kein Fehler
- ESLint: keine neuen Fehler (vorhandene Fehler in Basis-Branch pre-existing)