### PR TITLE
[Fix] #29: Critic gibt [Studie]-Platzhalter statt echten Paper-Titeln aus

### DIFF
--- a/agents/hypothesis-critic.ts
+++ b/agents/hypothesis-critic.ts
@@ -145,9 +145,25 @@ Antworte NUR mit diesem JSON (kein Markdown):
     .filter((n) => typeof n === "number" && n >= 1 && n <= slicedPapers.length)
     .map((n) => slicedPapers[n - 1].id);
 
-  // Sicherheitsnetz: Firestore-IDs (genau 20 alphanumerische Zeichen) aus dem
-  // argument-Text entfernen, falls das Modell sie trotz Prompt-Anweisung ausgibt.
-  const safeArgument = (parsed.argument ?? "").replace(/\b[A-Za-z0-9]{20}\b/g, "[Studie]");
+  // Sicherheitsnetz: Rohe Firestore-IDs und Nummern-Referenzen aus dem argument-Text
+  // entfernen und durch echte Studientitel ersetzen.
+  const idToTitle = new Map(slicedPapers.map((p) => [p.id, p.title]));
+
+  // 1. Ersetze rohe Firestore-IDs (20 alphanumerische Zeichen) durch Studientitel
+  let safeArgument = (parsed.argument ?? "").replace(/\b([A-Za-z0-9]{20})\b/g, (_match: string, id: string) => {
+    const title = idToTitle.get(id);
+    return title ? `„${title}"` : "[unbekannte Studie]";
+  });
+
+  // 2. Ersetze verbleibende Platzhalter wie [Studie], [1], [2] etc. durch echte Titel
+  safeArgument = safeArgument.replace(/\[Studie(?:\s+\d+)?\]/g, "[unbekannte Studie]");
+  safeArgument = safeArgument.replace(/\[([0-9]+)\]/g, (_match: string, numStr: string) => {
+    const n = parseInt(numStr, 10);
+    if (n >= 1 && n <= slicedPapers.length) {
+      return `„${slicedPapers[n - 1].title}"`;
+    }
+    return "[unbekannte Studie]";
+  });
 
   return {
     verdict: parsed.verdict,

--- a/agents/hypothesis-generator.ts
+++ b/agents/hypothesis-generator.ts
@@ -66,8 +66,8 @@ async function generateHypotheses(papers: Paper[]): Promise<
   const paperSummaries = papers
     .slice(0, 20)
     .map(
-      (p, i) =>
-        `[${i + 1}] ID:${p.id}\nTitel: ${p.title}\nEvidenz: ${p.evidenceLevel ?? "?"}\nZusammenfassung: ${(p.summary || p.abstract).slice(0, 400)}`
+      (p) =>
+        `ID:${p.id}\nTitel: ${p.title}\nEvidenz: ${p.evidenceLevel ?? "?"}\nZusammenfassung: ${(p.summary || p.abstract).slice(0, 400)}`
     )
     .join("\n\n---\n\n");
 
@@ -89,7 +89,7 @@ Antworte NUR mit diesem JSON-Array (kein Markdown):
   {
     "title": "Kurzer Hypothesentitel (max 80 Zeichen)",
     "description": "Vollständige Hypothese in 2-3 Sätzen",
-    "rationale": "Warum legen die Paper das nahe? Nenne die relevanten Paper beim Titel (keine IDs oder Nummern wie 'Paper 1')",
+    "rationale": "Warum legen die Paper das nahe? Zitiere ausschließlich den vollen Studientitel (z.B. 'Die Studie „Titel..." zeigt...') — NIEMALS Nummern wie [1], [6], 'Paper 1' oder rohe IDs",
     "paperIds": ["id1", "id2"]
   }
 ]`;


### PR DESCRIPTION
Fixes #29

## Ursache

Der safeArgument-Sanitizer in hypothesis-critic.ts ersetzte Firestore-IDs mit dem Literal-String '[Studie]' — genau der Platzhalter-Text im Bug-Report. Außerdem verwendete hypothesis-generator [i+1]-Indizes in der Paper-Liste, was das Modell zu [6]- und [18]-Kurzreferenzen im rationale-Text verleitet statt volle Studientitel.

## Änderungen

### agents/hypothesis-critic.ts
- safeArgument-Sanitizer schlägt Firestore-ID in idToTitle-Map nach und gibt echten Studientitel zurück
- Zusätzliche Nachbearbeitung: '[Studie]'- und '[N]'-Platzhalter im argument-Text werden durch den korrekten Studientitel aus slicedPapers ersetzt
- Fallback auf '[unbekannte Studie]' wenn ID nicht im Kontext

### agents/hypothesis-generator.ts
- [i+1]-Index aus paperSummaries-Format entfernt
- Prompt-Anweisung für rationale-Feld verschärft: explizites Verbot von [1], [6], 'Paper 1' etc.

## Test
- npx tsc --noEmit (agents/): keine neuen Fehler
- ESLint Frontend: nur pre-existente Fehler (identisch mit main)