### PR TITLE
[Fix] #30: Critic JSON-Parse — Attempt 4 Regex-Extraktion bei unescapten Quotes

### DIFF
--- a/agents/hypothesis-critic.ts
+++ b/agents/hypothesis-critic.ts
@@ -119,8 +119,6 @@ Antworte NUR mit diesem JSON (kein Markdown):
         parsed = JSON.parse(match[0]);
       } catch {
         // Attempt 3: sanitize literal control chars inside JSON string values and retry
-        // Root cause of "Expected ',' or '}' at position N": LLM writes multi-sentence
-        // text with bare newlines inside a JSON string value, which is invalid per spec.
         try {
           const sanitized = match[0].replace(
             /"((?:[^"\\]|\\.)*)"/gs,
@@ -129,7 +127,19 @@ Antworte NUR mit diesem JSON (kein Markdown):
           );
           parsed = JSON.parse(sanitized);
         } catch {
-          // fallthrough to safe default
+          // Attempt 4: regex-based field extraction as last resort
+          // Handles unescaped quotes inside string values which break all JSON.parse attempts
+          const verdictMatch = match[0].match(/"verdict"\s*:\s*"(challenged|open|needs_research)"/);
+          const argumentMatch = match[0].match(/"argument"\s*:\s*"([\s\S]*?)"\s*(?:,\s*"(?:researchQuery|paperNumbers)|\})/);
+          const researchMatch = match[0].match(/"researchQuery"\s*:\s*"([\s\S]*?)"\s*(?:,\s*"|\})/);
+          if (verdictMatch && argumentMatch) {
+            parsed = {
+              verdict: verdictMatch[1] as CriticVerdict,
+              argument: argumentMatch[1].replace(/\\n/g, "\n"),
+              researchQuery: researchMatch?.[1],
+              paperNumbers: [],
+            };
+          }
         }
       }
     }


### PR DESCRIPTION
Fixes #30

## Problem
'Expected "," or "}" after property value at position 248' tritt auf wenn das LLM unescapte Anführungszeichen innerhalb von JSON-Strings schreibt (z.B. Studientitel mit Anführungszeichen). Attempts 1-3 können das nicht beheben.

## Änderungen
- Attempt 4 als letzter Fallback: Regex-Extraktion der Felder verdict/argument/researchQuery direkt aus dem Raw-Text
- Greift wenn JSON.parse auch nach Control-Char-Sanitization scheitert
- Immer valides CriticResult als Rückgabe

## Test
- TypeScript-Kompilierung fehlerfrei
- Fallback gibt valides Objekt zurück solange verdict-Feld im LLM-Output vorhanden