### PR TITLE
[Fix] #34: jsonrepair für dauerhafte Behebung des Hypothesis-Critic-JSON-Parse-Fehlers

### DIFF
--- a/agents/hypothesis-critic.ts
+++ b/agents/hypothesis-critic.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "fs";
 import { initializeApp, cert, type ServiceAccount } from "firebase-admin/app";
 import { getFirestore, Timestamp } from "firebase-admin/firestore";
 import Anthropic from "@anthropic-ai/sdk";
+import { jsonrepair } from "jsonrepair";
 import { initLogger, logStart, logComplete, logError, logEvent } from "./lib/logger.js";
 
 const serviceAccount = JSON.parse(
@@ -112,39 +113,27 @@ Antworte NUR mit diesem JSON (kein Markdown):
   try {
     parsed = JSON.parse(text);
   } catch {
-    // Attempt 2: extract first {...} block (handles leading/trailing prose)
-    const match = text.match(/\{[\s\S]*\}/);
-    if (match) {
-      try {
-        parsed = JSON.parse(match[0]);
-      } catch {
-        // Attempt 3: sanitize literal control chars inside JSON string values and retry
-        try {
-          const sanitized = match[0].replace(
-            /"((?:[^"\\]|\\.)*)"/gs,
-            (_m: string, inner: string) =>
-              `"${inner.replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t")}"`
-          );
-          parsed = JSON.parse(sanitized);
-        } catch {
-          // Attempt 4: regex-based field extraction as last resort
-          // Handles unescaped quotes inside string values which break all JSON.parse attempts
-          const verdictMatch = match[0].match(/"verdict"\s*:\s*"(challenged|open|needs_research)"/);
-          const argumentMatch = match[0].match(/"argument"\s*:\s*"([\s\S]*?)"\s*(?:,\s*"(?:researchQuery|paperNumbers)|\})/);
-          const researchMatch = match[0].match(/"researchQuery"\s*:\s*"([\s\S]*?)"\s*(?:,\s*"|\})/);
-          if (verdictMatch && argumentMatch) {
-            parsed = {
-              verdict: verdictMatch[1] as CriticVerdict,
-              argument: argumentMatch[1].replace(/\\n/g, "\n"),
-              researchQuery: researchMatch?.[1],
-              paperNumbers: [],
-            };
-          }
-        }
+    // Attempt 2: jsonrepair — handles structural errors (missing commas/braces),
+    // unescaped quotes, control characters and other malformed LLM output.
+    // This is the primary fix for the recurring "Expected ',' or '}'" regression (#30, #33, #34).
+    const block = text.match(/\{[\s\S]*\}/)?.[0] ?? text;
+    try {
+      parsed = JSON.parse(jsonrepair(block));
+    } catch {
+      // Attempt 3: regex-based field extraction as absolute last resort
+      const verdictMatch = block.match(/"verdict"\s*:\s*"(challenged|open|needs_research)"/);
+      const argumentMatch = block.match(/"argument"\s*:\s*"([\s\S]*?)"\s*(?:,\s*"(?:researchQuery|paperNumbers)|\})/);
+      const researchMatch = block.match(/"researchQuery"\s*:\s*"([\s\S]*?)"\s*(?:,\s*"|\})/);
+      if (verdictMatch && argumentMatch) {
+        parsed = {
+          verdict: verdictMatch[1] as CriticVerdict,
+          argument: argumentMatch[1].replace(/\\n/g, "\n"),
+          researchQuery: researchMatch?.[1],
+          paperNumbers: [],
+        };
       }
     }
   }
-
   if (!parsed) {
     console.warn(`JSON parse failed for hypothesis "${hypothesis.title.slice(0, 50)}". Response: ${rawText.slice(0, 300)}`);
     return { verdict: "open", argument: "Parse-Fehler — manuelle Prüfung nötig", paperIds: [] };


### PR DESCRIPTION
Fixes #34

## Problem
Der Hypothesis Critic ist zum dritten Mal mit demselben JSON-Parse-Fehler abgestürzt:
`Expected ',' or '}' after property value in JSON at position 248`

Die Vorgänger-Fixes (#30, #33) haben jeweils nur spezifische Fehlervarianten behandelt (Steuerzeichen, Regex-Fallback), aber nicht die Root Cause: das LLM gibt gelegentlich strukturell ungültiges JSON aus (fehlende Kommas, nicht-escapte Anführungszeichen, falsche Klammerstruktur).

## Lösung
`jsonrepair` war bereits in `agents/package.json` als Dependency vorhanden, wurde aber nie genutzt. Die Bibliothek ist speziell dafür entwickelt, malformed LLM-JSON zu reparieren und deckt alle bekannten Fehlermuster ab.

**Vorher:** 4 verschachtelte try/catch-Blöcke (direkte Parse → Block-Extraktion → Steuerzeichen-Sanitize → Regex-Fallback)
**Nachher:** 2 Versuche: direkte Parse → `jsonrepair` → Regex-Fallback

## Änderungen
- `agents/hypothesis-critic.ts`: `jsonrepair` importiert und als primäre Reparatur-Strategie eingesetzt
- Fallback-Kette von 4 auf 3 Stufen vereinfacht (Versuch 1: direkt, Versuch 2: jsonrepair, Versuch 3: Regex)
- Code um ~11 Zeilen netto reduziert, deutlich lesbarer

## Test
- TypeScript-Check: `npx tsc --noEmit` → keine Fehler
- jsonrepair ist in `agents/package.json` bereits als Dependency gelistet (v3.13.3)