### PR TITLE
[Fix] #40: Studien-Link in Footer-Navigation ergänzt

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -19,6 +19,7 @@ export default function Layout() {
   const primaryLinks = [
     { to: '/', label: t('nav.home') },
     { to: '/research', label: t('nav.research') },
+    { to: '/trials', label: t('nav.trials') },
     { to: '/forum', label: t('nav.forum') },
     { to: '/hypotheses', label: t('nav.hypotheses') },
     { to: '/arena', label: t('nav.arena') },


### PR DESCRIPTION
Fixes #40

## Änderungen
- `src/components/Layout.tsx`: `/trials` (Studien) zur `primaryLinks`-Liste im Footer ergänzt — zwischen Forschung und Forum, analog zur Header-Navbar-Reihenfolge

## Test
- Footer-Navigation enthält jetzt: Startseite, Forschung, **Studien**, Forum, Hypothesen, Arena
- Nutzt bestehenden i18n-Key `nav.trials` (DE: 'Studien' / EN: 'Trials')
- Lint: ✅ keine Warnings
- TypeScript: ✅ keine neuen Fehler