### PR TITLE
[Fix] #44: Hypothesen-Fehler sichtbar machen (Error-State statt leerem Zustand)

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -59,15 +59,15 @@
     "how_step4_title": "Muster erkennen",
     "how_step4_text": "Langfristig sollen die Agenten über die gesammelte Forschung hinausdenken — und Zusammenhänge sichtbar machen, die bisher niemand explizit beschrieben hat.",
     "how_badge": "Betrieben mit OpenClaw & Claude",
-    "contribute_badge": "Offen f\u00fcr Agenten",
+    "contribute_badge": "Offen für Agenten",
     "contribute_title": "Lass deinen Agenten zur Forschung beitragen",
-    "contribute_intro": "SpondylAtlas ist offen f\u00fcr externe KI-Agenten. Baue einen OpenClaw-Agenten, der Studien sucht, bewertet und Hypothesen pr\u00fcft \u2014 und hilf mit, das Wissen \u00fcber Morbus Bechterew zu erweitern.",
+    "contribute_intro": "SpondylAtlas ist offen für externe KI-Agenten. Baue einen OpenClaw-Agenten, der Studien sucht, bewertet und Hypothesen prüft — und hilf mit, das Wissen über Morbus Bechterew zu erweitern.",
     "contribute_step1_title": "Zugang erhalten",
-    "contribute_step1_text": "Registriere deinen Agenten und erhalte API-Zugangsdaten mit abgestuften Berechtigungen \u2014 vom Reviewer bis zum vollwertigen Researcher.",
+    "contribute_step1_text": "Registriere deinen Agenten und erhalte API-Zugangsdaten mit abgestuften Berechtigungen — vom Reviewer bis zum vollwertigen Researcher.",
     "contribute_step2_title": "Agenten bauen",
     "contribute_step2_text": "Nutze das TypeScript SDK oder den OpenClaw Skill, um deinen Agenten mit der SpondylAtlas-Forschungsdatenbank zu verbinden.",
     "contribute_step3_title": "Zur Wissenschaft beitragen",
-    "contribute_step3_text": "Dein Agent reviewt Paper, bewertet Evidenzqualit\u00e4t und hinterfragt Hypothesen \u2014 und erweitert so die Wissensbasis f\u00fcr alle.",
+    "contribute_step3_text": "Dein Agent reviewt Paper, bewertet Evidenzqualität und hinterfragt Hypothesen — und erweitert so die Wissensbasis für alle.",
     "contribute_cta_github": "Auf GitHub ansehen",
     "contribute_cta_docs": "Dokumentation lesen"
   },
@@ -184,7 +184,9 @@
     "login_to_comment": "Anmelden",
     "login_to_comment_suffix": "um zu kommentieren.",
     "status_open_desc": "Nicht widerlegbar — Hypothese steht im Raum.",
-    "status_challenged_desc": "Der Critic-Agent hat Gegenargumente gefunden."
+    "status_challenged_desc": "Der Critic-Agent hat Gegenargumente gefunden.",
+    "error_title": "Hypothesen konnten nicht geladen werden",
+    "error_text": "Es gab einen Fehler beim Abrufen der Daten. Bitte versuche es später erneut."
   },
   "trials": {
     "title": "Klinische Studien",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -184,7 +184,9 @@
     "login_to_comment": "Sign in",
     "login_to_comment_suffix": "to comment.",
     "status_open_desc": "Not refutable — the hypothesis stands.",
-    "status_challenged_desc": "The critic agent has found counter-arguments."
+    "status_challenged_desc": "The critic agent has found counter-arguments.",
+    "error_title": "Could not load hypotheses",
+    "error_text": "There was an error fetching the data. Please try again later."
   },
   "trials": {
     "title": "Clinical Trials",

--- a/src/lib/hypotheses.ts
+++ b/src/lib/hypotheses.ts
@@ -43,17 +43,22 @@ export async function getHypothesis(id: string): Promise<HypothesisDetail | null
   }
 }
 
-export function subscribeHypotheses(cb: (h: Hypothesis[]) => void) {
+export function subscribeHypotheses(
+  cb: (h: Hypothesis[]) => void,
+  onError?: (err: Error | null) => void,
+) {
   let cancelled = false
 
   const load = async () => {
     try {
       const hypotheses = await getPublishedHypotheses()
       if (!cancelled) {
+        onError?.(null)
         cb(hypotheses)
       }
-    } catch {
+    } catch (err) {
       if (!cancelled) {
+        onError?.(err instanceof Error ? err : new Error(String(err)))
         cb([])
       }
     }

--- a/src/pages/Hypotheses.tsx
+++ b/src/pages/Hypotheses.tsx
@@ -48,12 +48,19 @@ export default function Hypotheses() {
   const { t } = useTranslation()
   const [hypotheses, setHypotheses] = useState<Hypothesis[]>([])
   const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
 
   useEffect(() => {
-    const unsub = subscribeHypotheses(h => {
-      setHypotheses(h)
-      setLoading(false)
-    })
+    const unsub = subscribeHypotheses(
+      h => {
+        setHypotheses(h)
+        setLoading(false)
+      },
+      err => {
+        setError(err)
+        setLoading(false)
+      },
+    )
     return unsub
   }, [])
 
@@ -80,7 +87,15 @@ export default function Hypotheses() {
 
       {loading && <div className="mt-8"><CardListSkeleton count={3} /></div>}
 
-      {!loading && hypotheses.length === 0 && (
+      {!loading && error && (
+        <div className="mt-8 rounded-xl border border-red-200 bg-red-50 p-6 text-sm text-red-700">
+          <p className="font-semibold"> {t('hypotheses.error_title')}</p>
+          <p className="mt-1 text-red-600">{t('hypotheses.error_text')}</p>
+          <p className="mt-2 font-mono text-xs text-red-400">{error.message}</p>
+        </div>
+      )}
+
+      {!loading && !error && hypotheses.length === 0 && (
         <div className="mt-8">
           <EmptyState
             icon=""


### PR DESCRIPTION
Fixes #44

## Problem
Die `subscribeHypotheses`-Funktion fing API-Fehler still ab und rief `cb([])` auf. Dadurch zeigte die Seite immer den "Die Agenten arbeiten noch"-Text, auch wenn ein echter Fehler (z.B. API-Ausfall, fehlendes Index, Berechtigungsproblem) die Ursache war.

## Änderungen
- `src/lib/hypotheses.ts`: `subscribeHypotheses` nimmt jetzt einen optionalen `onError`-Callback und propagiert Fehler statt sie zu schlucken
- `src/pages/Hypotheses.tsx`: Neuer Error-State mit roter Box und Fehlermeldung (inkl. technischer Message für Debugging)
- `src/i18n/locales/de.json`: Neue Keys `error_title` und `error_text` (Deutsch)
- `src/i18n/locales/en.json`: Neue Keys `error_title` und `error_text` (Englisch)

## Hinweis
Das eigentliche Datenproblem (leere Firestore-Collection) ist ein Infrastruktur-/Agent-Thema und braucht einen manuellen Neustart der Hypothesis-Pipeline. Dieses PR macht den Fehler zumindest sichtbar.

## Test
- TypeScript: `npx tsc -p tsconfig.app.json --noEmit` → keine Fehler
- Lint: `npx eslint src/pages/Hypotheses.tsx src/lib/hypotheses.ts --max-warnings 0` → keine Warnings