### PR TITLE
[Fix] #49: Forum-Route leitet korrekt auf /login weiter + Redirect nach Login

### DIFF
--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import type { ReactNode } from 'react'
-import { Link, Navigate } from 'react-router-dom'
+import { Link, Navigate, useLocation } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useAuth } from '../contexts/AuthContext'
 import { getHealthDataConsent } from '../lib/compliance'
@@ -16,15 +16,16 @@ export default function ProtectedRoute({
 }) {
   const { i18n } = useTranslation()
   const { user, loading, resendVerificationEmail } = useAuth()
+  const location = useLocation()
   const isGerman = i18n.language.startsWith('de')
   const [consentLoading, setConsentLoading] = useState(requireHealthConsent)
   const [hasHealthConsent, setHasHealthConsent] = useState(false)
-
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (!requireHealthConsent || !user) {
+      /* eslint-disable react-hooks/set-state-in-effect */
       setConsentLoading(false)
       setHasHealthConsent(false)
+      /* eslint-enable react-hooks/set-state-in-effect */
       return
     }
 
@@ -57,7 +58,7 @@ export default function ProtectedRoute({
   }
 
   if (!user) {
-    return <Navigate to="/login" replace />
+    return <Navigate to="/login" replace state={{ from: location }} />
   }
 
   if (requireVerifiedEmail && !user.emailVerified) {

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { FirebaseError } from 'firebase/app'
 import { useAuth } from '../contexts/AuthContext'
@@ -9,6 +9,8 @@ export default function Login() {
   const { t, i18n } = useTranslation()
   const { login } = useAuth()
   const navigate = useNavigate()
+  const location = useLocation()
+  const from = (location.state as { from?: Location } | null)?.from?.pathname ?? '/profile'
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
@@ -27,7 +29,7 @@ export default function Login() {
 
     try {
       await login(email, password)
-      navigate('/profile')
+      navigate(from, { replace: true })
     } catch (submitError) {
       if (submitError instanceof FirebaseError && submitError.code === 'auth/invalid-credential') {
         setError(t('auth.error_invalid_credentials'))
@@ -47,6 +49,14 @@ export default function Login() {
           ? 'Die Community ist nur für volljährige Nutzer vorgesehen. Für den Zugang zum geschützten Bereich ist eine bestätigte E-Mail-Adresse erforderlich.'
           : 'The community is intended for adult users only. A verified email address is required for access to the protected area.'}
       </p>
+
+      {from !== '/profile' && (
+        <div className="mt-4 rounded-lg bg-sky-50 border border-sky-200 p-3 text-sm text-sky-700">
+          {isGerman
+            ? 'Bitte melde dich an, um diesen Bereich zu sehen.'
+            : 'Please sign in to access this area.'}
+        </div>
+      )}
 
       {error && (
         <div className="mt-4 rounded-lg bg-red-50 p-3 text-sm text-red-700">{error}</div>


### PR DESCRIPTION
Fixes #49

## Änderungen
- `ProtectedRoute`: Übergibt `state={{ from: location }}` beim Weiterleiten auf /login, sodass der ursprüngliche Pfad nach dem Login wiederhergestellt werden kann
- `Login`: Liest `location.state.from` aus und leitet nach erfolgreichem Login dorthin zurück (statt immer auf /profile)
- `Login`: Zeigt einen kontextuellen Hinweis (blauer Banner) wenn Nutzer von einer geschützten Route weitergeleitet wurden (z.B. "Bitte melde dich an, um diesen Bereich zu sehen.")
- Entfernt unnötigen `eslint-disable`-Kommentar, ersetzt durch korrekte Block-Direktive

## Test
- Nicht eingeloggt /forum aufrufen → URL wechselt auf /login, blauer Hinweis sichtbar
- Nach Login wird man zurück auf /forum geleitet
- Direkter /login-Aufruf ohne vorherige Route: kein Hinweis, Redirect nach /profile