### PR TITLE
[Fix] #48: Impressum-Entwicklerhinweis entfernt

### DIFF
--- a/src/lib/legal.ts
+++ b/src/lib/legal.ts
@@ -78,15 +78,6 @@ export const LEGAL_DOCUMENTS: Record<LegalDocumentKey, LegalDocument> = {
           },
         ],
       },
-      {
-        title: { de: 'Hinweis vor Produktionsstart', en: 'Required Before Production' },
-        paragraphs: [
-          {
-            de: 'Die markierten Platzhalter müssen vor dem Go-Live mit den realen Betreiberangaben ersetzt werden.',
-            en: 'The placeholders on this page must be replaced with the real operator details before go-live.',
-          },
-        ],
-      },
     ],
   },
   privacy: {


### PR DESCRIPTION
Fixes #48

## Änderungen
- Abschnitt "Hinweis vor Produktionsstart" ("Required Before Production") aus dem Impressum-Dokument in `src/lib/legal.ts` entfernt
- Die eigentlichen Pflichtangaben (Anbieter, Kontakt) bleiben vollständig erhalten

## Test
- ESLint: keine Warnings
- TypeScript: kein Fehler
- Manuell geprüft: Impressum-Sektion enthält nur noch `Diensteanbieter` und `Kontakt`