### PR TITLE
[Fix] #55: Hypotheses 'Missing Bearer token' für unauthentifizierte User

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,11 +44,18 @@ jobs:
           channelId: live
           projectId: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
 
-      - name: Deploy Firestore Rules & Indexes (production)
+      - name: Build Functions
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          cd functions
+          npm ci
+          npm run build
+
+      - name: Deploy Functions, Firestore Rules & Indexes (production)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           npm install -g firebase-tools
-          firebase deploy --only firestore:rules,firestore:indexes \
+          firebase deploy --only functions,firestore:rules,firestore:indexes \
             --project "$FIREBASE_PROJECT_ID" \
             --token "$FIREBASE_TOKEN" \
             --non-interactive

--- a/src/pages/Hypotheses.tsx
+++ b/src/pages/Hypotheses.tsx
@@ -91,7 +91,7 @@ export default function Hypotheses() {
         <div className="mt-8 rounded-xl border border-red-200 bg-red-50 p-6 text-sm text-red-700">
           <p className="font-semibold"> {t('hypotheses.error_title')}</p>
           <p className="mt-1 text-red-600">{t('hypotheses.error_text')}</p>
-          <p className="mt-2 font-mono text-xs text-red-400">{error.message}</p>
+
         </div>
       )}
 


### PR DESCRIPTION
Fixes #55

## Root Cause
Die CI/CD Pipeline (deploy.yml) hat **Firebase Functions nicht deployed** — nur Hosting und Firestore Rules. Die in `f0dbe32` hinzugefügten `/public` API-Routes existierten daher nie in Production. Requests an `/api/public/hypotheses` fielen durch zum globalen `authMiddleware`, das einen Bearer Token verlangt.

## Änderungen
1. **`.github/workflows/deploy.yml`**: Functions-Build + Deploy hinzugefügt (`--only functions,firestore:rules,firestore:indexes`)
2. **`src/pages/Hypotheses.tsx`**: Raw Error-Message (`error.message`) aus der Fehleranzeige entfernt — User sehen nur noch den i18n-Text, nicht den technischen Hinweis 'Missing Bearer token'

## Test
- `npx tsc -b --noEmit` ✅
- `npx eslint src/pages/Hypotheses.tsx --max-warnings 0` ✅
- Nach Merge: CI deployt Functions → `/public/hypotheses` Endpoint verfügbar → kein Auth-Error mehr