### PR TITLE
[Fix] #57: Arena page error handling for unauthenticated users

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -230,7 +230,9 @@
     "table_status": "Status",
     "table_result": "Ergebnis",
     "table_items": "Elemente",
-    "table_time": "Zeit"
+    "table_time": "Zeit",
+    "error_title": "Daten konnten nicht geladen werden",
+    "error_text": "Die Arena-Daten sind derzeit nicht verfügbar. Bitte versuche es später erneut."
   },
   "common": {
     "loading": "Einen Moment...",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -230,7 +230,9 @@
     "table_status": "Status",
     "table_result": "Result",
     "table_items": "Items",
-    "table_time": "Time"
+    "table_time": "Time",
+    "error_title": "Could not load data",
+    "error_text": "Arena data is currently unavailable. Please try again later."
   },
   "common": {
     "loading": "Just a moment...",

--- a/src/lib/agentArena.ts
+++ b/src/lib/agentArena.ts
@@ -57,16 +57,22 @@ async function loadArena() {
   return apiFetch<ArenaPayload>('/public/arena')
 }
 
-export function subscribeToEvents(
-  cb: (events: AgentEvent[]) => void,
-  _maxItems = 100, // eslint-disable-line @typescript-eslint/no-unused-vars
+export function subscribeToArena(
+  onData: (payload: { events: AgentEvent[]; runs: AgentRun[] }) => void,
+  onError: (err: Error) => void,
 ) {
   let cancelled = false
 
   const load = async () => {
-    const { events } = await loadArena()
-    if (!cancelled) {
-      cb(events)
+    try {
+      const data = await loadArena()
+      if (!cancelled) {
+        onData(data)
+      }
+    } catch (err) {
+      if (!cancelled) {
+        onError(err instanceof Error ? err : new Error(String(err)))
+      }
     }
   }
 
@@ -79,24 +85,18 @@ export function subscribeToEvents(
   }
 }
 
+/** @deprecated Use subscribeToArena instead */
+export function subscribeToEvents(
+  cb: (events: AgentEvent[]) => void,
+  _maxItems = 100, // eslint-disable-line @typescript-eslint/no-unused-vars
+) {
+  return subscribeToArena(({ events }) => cb(events), () => {})
+}
+
+/** @deprecated Use subscribeToArena instead */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function subscribeToRuns(cb: (runs: AgentRun[]) => void, _maxItems = 50) {
-  let cancelled = false
-
-  const load = async () => {
-    const { runs } = await loadArena()
-    if (!cancelled) {
-      cb(runs)
-    }
-  }
-
-  void load()
-  const interval = window.setInterval(() => void load(), 30000)
-
-  return () => {
-    cancelled = true
-    window.clearInterval(interval)
-  }
+  return subscribeToArena(({ runs }) => cb(runs), () => {})
 }
 
 export function formatRelative(ts: string | { toDate(): Date } | null): string {

--- a/src/pages/AgentArena.tsx
+++ b/src/pages/AgentArena.tsx
@@ -2,8 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
-  subscribeToEvents,
-  subscribeToRuns,
+  subscribeToArena,
   formatRelative,
   durationSec,
   AGENT_META,
@@ -164,24 +163,32 @@ export default function AgentArena() {
 
   const [events, setEvents] = useState<AgentEvent[]>([])
   const [runs, setRuns] = useState<AgentRun[]>([])
+  const [error, setError] = useState<Error | null>(null)
   const [newIds, setNewIds] = useState<Set<string>>(new Set())
   const [autoScroll, setAutoScroll] = useState(true)
   const feedRef = useRef<HTMLDivElement>(null)
   const prevIds = useRef<Set<string>>(new Set())
 
   useEffect(() => {
-    const unsub1 = subscribeToEvents((ev) => {
-      const incoming = new Set(ev.map((e) => e.id))
-      const fresh = ev.filter((e) => !prevIds.current.has(e.id)).map((e) => e.id)
-      if (fresh.length) {
-        setNewIds(new Set(fresh))
-        setTimeout(() => setNewIds(new Set()), 2000)
-      }
-      prevIds.current = incoming
-      setEvents(ev)
-    })
-    const unsub2 = subscribeToRuns(setRuns)
-    return () => { unsub1(); unsub2() }
+    const unsub = subscribeToArena(
+      ({ events: ev, runs: r }) => {
+        setError(null)
+
+        const incoming = new Set(ev.map((e) => e.id))
+        const fresh = ev.filter((e) => !prevIds.current.has(e.id)).map((e) => e.id)
+        if (fresh.length) {
+          setNewIds(new Set(fresh))
+          setTimeout(() => setNewIds(new Set()), 2000)
+        }
+        prevIds.current = incoming
+        setEvents(ev)
+        setRuns(r)
+      },
+      (err) => {
+        setError(err)
+      },
+    )
+    return unsub
   }, [])
 
   useEffect(() => {
@@ -198,6 +205,19 @@ export default function AgentArena() {
 
   const totalItems = runs.filter(r => r.status === 'complete').reduce((s, r) => s + r.itemsProcessed, 0)
   const activeAgents = Object.values(runsByAgent).filter(rs => rs[0]?.status === 'running').length
+
+  if (error) {
+    return (
+      <div className="mx-auto max-w-7xl px-4 py-8">
+        <h1 className="text-3xl font-bold text-stone-900">⚙️ {t('arena.title')}</h1>
+        <p className="mt-1 text-stone-500 text-sm">{t('arena.subtitle')}</p>
+        <div className="mt-8 rounded-xl border border-amber-200 bg-amber-50 p-6 text-sm text-amber-800">
+          <p className="font-semibold">{t('arena.error_title')}</p>
+          <p className="mt-1 text-amber-600">{t('arena.error_text')}</p>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="mx-auto max-w-7xl px-4 py-8">


### PR DESCRIPTION
Fixes #57

## Änderungen
- Neuer `subscribeToArena()` in `agentArena.ts` mit Error-Callback statt stiller Fehler
- `AgentArena.tsx` zeigt jetzt einen benutzerfreundlichen Fehler-Hinweis statt leerer Nullwerte bei API-Fehlern
- i18n-Keys `arena.error_title` / `arena.error_text` für DE + EN ergänzt
- Keine rohen Fehlermeldungen (z.B. 'Missing Bearer token') mehr sichtbar für Endnutzer

## Kontext
Das Backend (`/api/public/arena`) erfordert keine Authentifizierung — der Endpoint ist korrekt als public gemountet. Das Problem war, dass Fehler (z.B. wenn Functions nicht deployed waren, vgl. #55/#56) stillschweigend verschluckt wurden und die Seite einfach 0/0/0 anzeigte. Jetzt wird ein klarer Hinweis gezeigt.

## Test
- `npx tsc -b --noEmit` — ✅
- `npx eslint` — ✅