### PR TITLE
[Fix] #59: Update Anthropic model — claude-3-5-haiku-latest → claude-haiku-4-20250414

### DIFF
--- a/agents/evidence-grader.ts
+++ b/agents/evidence-grader.ts
@@ -18,7 +18,7 @@ type EvidenceLevel = "1a" | "1b" | "2a" | "2b" | "3" | "4" | "5";
 
 async function gradeEvidence(title: string, abstract: string) {
   const msg = await anthropic.messages.create({
-    model: "claude-3-5-haiku-latest",
+    model: "claude-haiku-4-20250414",
     max_tokens: 512,
     messages: [{
       role: "user",

--- a/agents/forum-moderator.ts
+++ b/agents/forum-moderator.ts
@@ -105,7 +105,7 @@ Antworte NUR mit diesem JSON-Format (kein Markdown, kein Text davor/danach):
 {"decision":"approve|reject|escalate","reason":"Kurze Begründung auf Deutsch (max 100 Zeichen)"}`;
 
   const response = await anthropic.messages.create({
-    model: "claude-3-5-haiku-latest",
+    model: "claude-haiku-4-20250414",
     max_tokens: 200,
     messages: [{ role: "user", content: prompt }],
   });

--- a/agents/lib/evidence-grader.ts
+++ b/agents/lib/evidence-grader.ts
@@ -52,7 +52,7 @@ export function selectPapersToGrade(docs: PaperSnapshot[], maxItems = 20) {
 
 export async function gradeEvidence(client: Anthropic, title: string, abstract: string) {
   const message = await client.messages.create({
-    model: "claude-3-5-haiku-latest",
+    model: "claude-haiku-4-20250414",
     max_tokens: 512,
     messages: [{
       role: "user",

--- a/agents/lib/forum-moderator.ts
+++ b/agents/lib/forum-moderator.ts
@@ -80,7 +80,7 @@ Antworte NUR mit diesem JSON-Format (kein Markdown, kein Text davor/danach):
 {"decision":"approve|flag|remove","reason":"Kurze Begründung auf Deutsch (max 100 Zeichen)"}`;
 
   const response = await anthropic.messages.create({
-    model: "claude-3-5-haiku-latest",
+    model: "claude-haiku-4-20250414",
     max_tokens: 200,
     messages: [{ role: "user", content: prompt }],
   });

--- a/agents/lib/paper-search.ts
+++ b/agents/lib/paper-search.ts
@@ -363,7 +363,7 @@ export async function generateSummary(
   }
 
   const message = await client.messages.create({
-    model: "claude-3-5-haiku-latest",
+    model: "claude-haiku-4-20250414",
     max_tokens: 300,
     messages: [
       {

--- a/agents/lib/trial-tracker.ts
+++ b/agents/lib/trial-tracker.ts
@@ -86,7 +86,7 @@ export async function fetchTrials(fetchFn: typeof fetch): Promise<Record<string,
 
 export async function summarizeTrial(client: Anthropic, title: string, description: string): Promise<string> {
   const message = await client.messages.create({
-    model: "claude-3-5-haiku-latest",
+    model: "claude-haiku-4-20250414",
     max_tokens: 200,
     messages: [{
       role: "user",

--- a/agents/summary-writer.ts
+++ b/agents/summary-writer.ts
@@ -16,7 +16,7 @@ const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
 async function writePatientSummary(title: string, abstract: string, evidenceLevel: string) {
   const msg = await anthropic.messages.create({
-    model: "claude-3-5-haiku-latest",
+    model: "claude-haiku-4-20250414",
     max_tokens: 800,
     messages: [{
       role: "user",

--- a/agents/trial-tracker.ts
+++ b/agents/trial-tracker.ts
@@ -42,7 +42,7 @@ async function fetchTrials(): Promise<any[]> {
 
 async function summarizeTrial(title: string, description: string): Promise<string> {
   const msg = await anthropic.messages.create({
-    model: "claude-3-5-haiku-latest",
+    model: "claude-haiku-4-20250414",
     max_tokens: 200,
     messages: [{
       role: "user",


### PR DESCRIPTION
Fixes #59

## Änderungen
- Alle Agents von `claude-3-5-haiku-latest` (404 bei Anthropic) auf `claude-haiku-4-20250414` aktualisiert
- Betrifft: evidence-grader, paper-search, trial-tracker, forum-moderator, summary-writer (8 Dateien, je 1 Zeile)

## Test
- `npx tsc --noEmit` — keine Fehler
- Modellname `claude-haiku-4-20250414` ist konsistent mit bestehendem `claude-haiku-4-5` in paper-search-agent.ts