### PR TITLE
[Fix] #63: Arena-Polling stoppt bei 401-Fehlern

### DIFF
--- a/src/lib/agentArena.ts
+++ b/src/lib/agentArena.ts
@@ -62,26 +62,46 @@ export function subscribeToArena(
   onError: (err: Error) => void,
 ) {
   let cancelled = false
+  let consecutiveErrors = 0
+  let interval: ReturnType<typeof setInterval> | null = null
+
+  const stopPolling = () => {
+    if (interval !== null) {
+      window.clearInterval(interval)
+      interval = null
+    }
+  }
 
   const load = async () => {
     try {
       const data = await loadArena()
       if (!cancelled) {
+        consecutiveErrors = 0
         onData(data)
       }
     } catch (err) {
       if (!cancelled) {
-        onError(err instanceof Error ? err : new Error(String(err)))
+        consecutiveErrors++
+        const message = err instanceof Error ? err.message : String(err)
+        // Stop polling on auth errors — repeated 401s are pointless
+        if (message.includes('401') || message.includes('Unauthorized')) {
+          stopPolling()
+        }
+        // Also stop after 5 consecutive errors of any kind
+        if (consecutiveErrors >= 5) {
+          stopPolling()
+        }
+        onError(err instanceof Error ? err : new Error(message))
       }
     }
   }
 
   void load()
-  const interval = window.setInterval(() => void load(), 30000)
+  interval = window.setInterval(() => void load(), 30000)
 
   return () => {
     cancelled = true
-    window.clearInterval(interval)
+    stopPolling()
   }
 }
 


### PR DESCRIPTION
Fixes #63

## Änderungen
- `subscribeToArena` stoppt das Polling sofort bei 401/Unauthorized-Fehlern
- Nach 5 aufeinanderfolgenden Fehlern (egal welcher Art) wird das Polling ebenfalls gestoppt
- Kein Spam mehr in der Browser-Konsole für nicht eingeloggte User

## Details
Das Problem: `subscribeToArena` pollt `/api/public/arena` alle 30s via `apiFetch`. Für unauthentifizierte User gibt der Server 401 zurück — das Polling lief trotzdem endlos weiter (~120 nutzlose Requests/Stunde).

Der Fix prüft die Fehlermeldung auf 401/Unauthorized und stoppt das Interval. Zusätzlich gibt es einen Fallback: nach 5 consecutive Errors wird generell gestoppt.

## Test
- TypeScript: `npx tsc -b --noEmit` ✅
- ESLint: `npx eslint src/lib/agentArena.ts --max-warnings 0` ✅