### PR TITLE
[Fix] #67: Critic zeigt echte Paper-Titel statt [Studie] Platzhalter

### DIFF
--- a/functions/src/routes/public.ts
+++ b/functions/src/routes/public.ts
@@ -21,6 +21,30 @@ function toIsoString(value: unknown) {
   return null;
 }
 
+/**
+ * Batch-fetch paper titles for a set of IDs.
+ * Returns a map of paperId → title.
+ */
+async function fetchPaperTitles(paperIds: string[]): Promise<Record<string, string>> {
+  const unique = [...new Set(paperIds)].filter(Boolean);
+  if (unique.length === 0) return {};
+
+  const titles: Record<string, string> = {};
+  for (let i = 0; i < unique.length; i += 30) {
+    const batch = unique.slice(i, i + 30);
+    const snap = await db()
+      .collection("papers")
+      .where("__name__", "in", batch)
+      .select("title")
+      .get();
+    for (const doc of snap.docs) {
+      titles[doc.id] = doc.data().title ?? "";
+    }
+  }
+  return titles;
+}
+
+
 function serializeHypothesis(doc: FirebaseFirestore.QueryDocumentSnapshot | FirebaseFirestore.DocumentSnapshot) {
   const data = doc.data();
   if (!data) {
@@ -117,8 +141,14 @@ router.get("/hypotheses", async (req, res, next) => {
       .orderBy("generatedAt", "desc");
 
     const snap = await query.limit(params.limit + params.offset).get();
-    const docs = snap.docs.slice(params.offset, params.offset + params.limit).map(serializeHypothesis);
-    res.json({ data: docs.filter(Boolean), total: snap.size, limit: params.limit, offset: params.offset });
+    const docs = snap.docs.slice(params.offset, params.offset + params.limit).map(serializeHypothesis).filter(Boolean);
+
+    // Enrich hypotheses with paper titles for critic references
+    const allCriticPaperIds = docs.flatMap((d: any) => d.criticPaperIds ?? []);
+    const paperTitles = await fetchPaperTitles(allCriticPaperIds);
+    const enriched = docs.map((d: any) => ({ ...d, criticPaperTitles: paperTitles }));
+
+    res.json({ data: enriched, total: snap.size, limit: params.limit, offset: params.offset });
   } catch (err) {
     next(err);
   }
@@ -143,8 +173,12 @@ router.get("/hypotheses/:id", async (req, res, next) => {
       .orderBy("createdAt", "asc")
       .get();
 
+    // Enrich with paper titles for critic references
+    const paperTitles = await fetchPaperTitles(hypothesis.criticPaperIds ?? []);
+
     res.json({
       ...hypothesis,
+      criticPaperTitles: paperTitles,
       comments: commentsSnap.docs.map(serializeHypothesisComment),
     });
   } catch (err) {

--- a/src/lib/hypotheses.ts
+++ b/src/lib/hypotheses.ts
@@ -12,6 +12,7 @@ export interface Hypothesis {
   generatedAt: string | null
   criticArgument?: string | null
   criticPaperIds?: string[]
+  criticPaperTitles?: Record<string, string>
   reviewedAt?: string | null
   commentCount?: number
 }
@@ -106,6 +107,10 @@ export function formatTs(ts: string | null | undefined): string {
  *
  * Beispiel: "Paper rtfu3ZjLMHc4VqMR6rLI zeigt..." → "Paper [Studie] zeigt..."
  */
-export function sanitizeCriticText(text: string): string {
-  return text.replace(/\b[A-Za-z0-9]{20}\b/g, '[Studie]')
+export function sanitizeCriticText(text: string, paperTitles?: Record<string, string>): string {
+  const titles = paperTitles ?? {}
+  return text.replace(/\b[A-Za-z0-9]{20}\b/g, (match) => {
+    const title = titles[match]
+    return title ? `„${title}"` : ''
+  })
 }

--- a/src/pages/Hypotheses.tsx
+++ b/src/pages/Hypotheses.tsx
@@ -30,7 +30,7 @@ function HypothesisCard({ h }: { h: Hypothesis }) {
       {h.status === 'challenged' && h.criticArgument && (
         <div className="mt-3 rounded-lg bg-red-50 border border-red-100 px-3 py-2 text-xs text-red-700">
           <span className="font-medium"> {t('hypotheses.criticism')}: </span>
-          {sanitizeCriticText(h.criticArgument).slice(0, 120)}…
+          {sanitizeCriticText(h.criticArgument, h.criticPaperTitles).slice(0, 120)}…
         </div>
       )}
       <div className="mt-4 flex items-center gap-4 text-xs text-stone-400">

--- a/src/pages/HypothesisDetail.tsx
+++ b/src/pages/HypothesisDetail.tsx
@@ -87,7 +87,7 @@ export default function HypothesisDetail() {
           <p className="text-xs font-semibold uppercase tracking-wide text-stone-500 mb-2">
              {t('hypotheses.critic_agent')} — {cfg ? t(cfg.descKey) : ''}
           </p>
-          <p className="text-sm text-stone-700 leading-relaxed">{sanitizeCriticText(hypo.criticArgument)}</p>
+          <p className="text-sm text-stone-700 leading-relaxed">{sanitizeCriticText(hypo.criticArgument, hypo.criticPaperTitles)}</p>
           {hypo.reviewedAt && (
             <p className="mt-2 text-xs text-stone-400">{t('hypotheses.reviewed_at', { date: formatTs(hypo.reviewedAt) })}</p>
           )}


### PR DESCRIPTION
Fixes #67

## Änderungen

### Backend
- Neue Helper-Funktion fetchPaperTitles - batch-fetcht Paper-Titel aus Firestore
- Hypothesen-Endpoints liefern jetzt criticPaperTitles Map mit

### Frontend
- sanitizeCriticText akzeptiert jetzt optionale paperTitles-Map
- Rohe Firestore-IDs werden zu echten Studientiteln aufgelöst
- Unbekannte IDs werden leer ersetzt statt als [Studie] angezeigt

## Ursache
sanitizeCriticText hat jeden 20-Zeichen alphanumerischen String blind durch [Studie] ersetzt.

## Test
- TypeScript: npx tsc -b --noEmit OK
- ESLint: keine Warnings