### PR TITLE
[Fix] #70: Mehrwortsuche in Research tokenisieren

### DIFF
--- a/src/pages/Research.test.tsx
+++ b/src/pages/Research.test.tsx
@@ -61,7 +61,34 @@ describe('Research page', () => {
     })
   })
 
-  it('renders fetch errors', async () => {
+  it('filters by multiple search terms (AND logic)', async () => {
+    const user = userEvent.setup()
+    getDocsMock.mockResolvedValue({
+      docs: [
+        { id: 'paper-1', data: () => buildPaper({ title: 'TNF inhibitors in AS', tags: ['TNF', 'Biologika'] }) },
+        { id: 'paper-2', data: () => buildPaper({ id: 'paper-2', title: 'Mikrobiom und Darm', tags: ['Mikrobiom'] }) },
+        { id: 'paper-3', data: () => buildPaper({ id: 'paper-3', title: 'TNF und Mikrobiom', tags: ['TNF'] }) },
+      ],
+    })
+
+    render(
+      <MemoryRouter>
+        <Research />
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByText('TNF inhibitors in AS')).toBeInTheDocument()
+
+    await user.type(screen.getByRole('searchbox'), 'TNF Biologika')
+
+    await waitFor(() => {
+      expect(screen.getByText('TNF inhibitors in AS')).toBeInTheDocument()
+      expect(screen.queryByText('Mikrobiom und Darm')).not.toBeInTheDocument()
+      expect(screen.queryByText('TNF und Mikrobiom')).not.toBeInTheDocument()
+    })
+  })
+
+    it('renders fetch errors', async () => {
     getDocsMock.mockRejectedValue(new Error('boom'))
 
     render(

--- a/src/pages/Research.tsx
+++ b/src/pages/Research.tsx
@@ -46,13 +46,15 @@ export default function Research() {
 
   const filtered = useMemo(() => {
     if (!search.trim()) return papers
-    const term = search.toLowerCase()
+    const terms = search.toLowerCase().split(/\s+/).filter(Boolean)
 
-    return papers.filter(
-      (paper) =>
-        paper.title.toLowerCase().includes(term) ||
-        paper.tags.some((tag) => tag.toLowerCase().includes(term)),
-    )
+    return papers.filter((paper) => {
+      const title = paper.title.toLowerCase()
+      const tagsJoined = paper.tags.map((tag) => tag.toLowerCase()).join(' ')
+      return terms.every(
+        (term) => title.includes(term) || tagsJoined.includes(term),
+      )
+    })
   }, [papers, search])
 
   const formatDate = (paper: Paper) => {


### PR DESCRIPTION
Fixes #70

## Änderungen
- Suchbegriffe werden an Leerzeichen tokenisiert
- AND-Logik: Jeder Term muss in Titel ODER Tags vorkommen
- Paper werden nur angezeigt wenn alle Suchbegriffe matchen (über Titel + Tags hinweg)

## Test
- Neuer Testcase für Mehrwortsuche (AND-Logik) hinzugefügt
- Alle 3 Tests bestanden
- Lint + TypeCheck sauber