### PR TITLE
fix(agents): summary writer model → claude-3-5-haiku-latest (#66)

### DIFF
--- a/agents/summary-writer.ts
+++ b/agents/summary-writer.ts
@@ -16,7 +16,7 @@ const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
 async function writePatientSummary(title: string, abstract: string, evidenceLevel: string) {
   const msg = await anthropic.messages.create({
-    model: "claude-haiku-4-20250414",
+    model: "claude-3-5-haiku-latest",
     max_tokens: 800,
     messages: [{
       role: "user",


### PR DESCRIPTION
Summary Writer used `claude-haiku-4-20250414` which returns 401. Changed to `claude-3-5-haiku-latest`. Closes #66.