### PR TITLE
fix(agents): all haiku models → claude-3-haiku-20240307 (#78)

### DIFF
--- a/agents/evidence-grader.ts
+++ b/agents/evidence-grader.ts
@@ -18,7 +18,7 @@ type EvidenceLevel = "1a" | "1b" | "2a" | "2b" | "3" | "4" | "5";
 
 async function gradeEvidence(title: string, abstract: string) {
   const msg = await anthropic.messages.create({
-    model: "claude-3-5-haiku-latest",
+    model: "claude-3-haiku-20240307",
     max_tokens: 512,
     messages: [{
       role: "user",

--- a/agents/forum-moderator.ts
+++ b/agents/forum-moderator.ts
@@ -105,7 +105,7 @@ Antworte NUR mit diesem JSON-Format (kein Markdown, kein Text davor/danach):
 {"decision":"approve|reject|escalate","reason":"Kurze Begründung auf Deutsch (max 100 Zeichen)"}`;
 
   const response = await anthropic.messages.create({
-    model: "claude-haiku-4-20250414",
+    model: "claude-3-haiku-20240307",
     max_tokens: 200,
     messages: [{ role: "user", content: prompt }],
   });

--- a/agents/lib/evidence-grader.ts
+++ b/agents/lib/evidence-grader.ts
@@ -52,7 +52,7 @@ export function selectPapersToGrade(docs: PaperSnapshot[], maxItems = 20) {
 
 export async function gradeEvidence(client: Anthropic, title: string, abstract: string) {
   const message = await client.messages.create({
-    model: "claude-3-5-haiku-latest",
+    model: "claude-3-haiku-20240307",
     max_tokens: 512,
     messages: [{
       role: "user",

--- a/agents/lib/forum-moderator.ts
+++ b/agents/lib/forum-moderator.ts
@@ -80,7 +80,7 @@ Antworte NUR mit diesem JSON-Format (kein Markdown, kein Text davor/danach):
 {"decision":"approve|flag|remove","reason":"Kurze Begründung auf Deutsch (max 100 Zeichen)"}`;
 
   const response = await anthropic.messages.create({
-    model: "claude-haiku-4-20250414",
+    model: "claude-3-haiku-20240307",
     max_tokens: 200,
     messages: [{ role: "user", content: prompt }],
   });

--- a/agents/lib/paper-search.ts
+++ b/agents/lib/paper-search.ts
@@ -363,7 +363,7 @@ export async function generateSummary(
   }
 
   const message = await client.messages.create({
-    model: "claude-haiku-4-20250414",
+    model: "claude-3-haiku-20240307",
     max_tokens: 300,
     messages: [
       {

--- a/agents/lib/trial-tracker.ts
+++ b/agents/lib/trial-tracker.ts
@@ -86,7 +86,7 @@ export async function fetchTrials(fetchFn: typeof fetch): Promise<Record<string,
 
 export async function summarizeTrial(client: Anthropic, title: string, description: string): Promise<string> {
   const message = await client.messages.create({
-    model: "claude-haiku-4-20250414",
+    model: "claude-3-haiku-20240307",
     max_tokens: 200,
     messages: [{
       role: "user",

--- a/agents/paper-search-agent.ts
+++ b/agents/paper-search-agent.ts
@@ -322,7 +322,7 @@ async function generateSummary(
   }
 
   const message = await client.messages.create({
-    model: "claude-haiku-4-5",
+    model: "claude-3-haiku-20240307",
     max_tokens: 300,
     messages: [
       {

--- a/agents/summary-writer.ts
+++ b/agents/summary-writer.ts
@@ -16,7 +16,7 @@ const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
 async function writePatientSummary(title: string, abstract: string, evidenceLevel: string) {
   const msg = await anthropic.messages.create({
-    model: "claude-3-5-haiku-latest",
+    model: "claude-3-haiku-20240307",
     max_tokens: 800,
     messages: [{
       role: "user",

--- a/agents/trial-tracker.ts
+++ b/agents/trial-tracker.ts
@@ -42,7 +42,7 @@ async function fetchTrials(): Promise<any[]> {
 
 async function summarizeTrial(title: string, description: string): Promise<string> {
   const msg = await anthropic.messages.create({
-    model: "claude-haiku-4-20250414",
+    model: "claude-3-haiku-20240307",
     max_tokens: 200,
     messages: [{
       role: "user",


### PR DESCRIPTION
All haiku-based agents were using non-existent model names that return 404:
- `claude-3-5-haiku-latest`
- `claude-haiku-4-20250414`  
- `claude-haiku-4-5`

Changed all 9 files to `claude-3-haiku-20240307`.

Closes #78.