### PR TITLE
feat: bilingual hypotheses (DE+EN)

### DIFF
--- a/agents/hypothesis-critic.ts
+++ b/agents/hypothesis-critic.ts
@@ -17,9 +17,14 @@ const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
 type CriticVerdict = "challenged" | "open" | "needs_research";
 
+interface BilingualField {
+  de: string;
+  en: string;
+}
+
 interface CriticResult {
   verdict: CriticVerdict;
-  argument: string;
+  argument: BilingualField;
   researchQuery?: string;
   paperIds: string[];
 }
@@ -77,6 +82,8 @@ Bewerte streng nach diesen Kategorien:
 - **needs_research**: Die vorhandenen Papers sind unvollständig. Definiere einen konkreten Rechercheauftrag.
 - **open**: Keine Widerlegung möglich, aber auch keine volle Bestätigung. Hypothese bleibt offen.
 
+WICHTIG: Das "argument"-Feld MUSS ein Objekt mit "de" und "en" sein (zweisprachig).
+
 WICHTIG für das "argument"-Feld:
 - Nenne Papers immer beim vollen Titel (z.B. 'Die Studie "Sex differences in clinical characteristics..." zeigt...')
 - Schreibe für Endnutzer verständlich — KEINE technischen IDs, KEINE Nummern wie "[1]" im Fließtext
@@ -88,7 +95,7 @@ WICHTIG für das "paperNumbers"-Feld:
 Antworte NUR mit diesem JSON (kein Markdown):
 {
   "verdict": "challenged|open|needs_research",
-  "argument": "Deine Begründung auf Deutsch (3-5 Sätze), Paper-Referenzen nur per vollem Titel",
+  "argument": { "de": "Deine Begründung auf Deutsch (3-5 Sätze), Paper-Referenzen nur per vollem Titel", "en": "Your reasoning in English (3-5 sentences), paper references by full title only" },
   "researchQuery": "Nur bei needs_research: Konkreter Suchauftrag für weitere Papers (1-2 Sätze)",
   "paperNumbers": [1, 2]
 }`;
@@ -107,7 +114,7 @@ Antworte NUR mit diesem JSON (kein Markdown):
     .replace(/\s*```\s*$/, "")
     .trim();
 
-  let parsed: { verdict: CriticVerdict; argument: string; researchQuery?: string; paperNumbers?: number[] } | null = null;
+  let parsed: { verdict: CriticVerdict; argument: string | BilingualField; researchQuery?: string; paperNumbers?: number[] } | null = null;
 
   // Attempt 1: direct parse
   try {
@@ -130,13 +137,13 @@ Antworte NUR mit diesem JSON (kein Markdown):
           argument: argumentMatch[1].replace(/\\n/g, "\n"),
           researchQuery: researchMatch?.[1],
           paperNumbers: [],
-        };
+        } as any;
       }
     }
   }
   if (!parsed) {
     console.warn(`JSON parse failed for hypothesis "${hypothesis.title.slice(0, 50)}". Response: ${rawText.slice(0, 300)}`);
-    return { verdict: "open", argument: "Parse-Fehler — manuelle Prüfung nötig", paperIds: [] };
+    return { verdict: "open", argument: { de: "Parse-Fehler — manuelle Prüfung nötig", en: "Parse error — manual review needed" }, paperIds: [] };
   }
 
   // Map 1-based paper numbers back to real Firestore IDs
@@ -218,7 +225,7 @@ async function main() {
     // Update hypothesis
     await doc.ref.update({
       status: result.verdict,
-      criticArgument: result.argument,
+      criticArgument: result.argument,  // BilingualField { de, en }
       criticPaperIds: result.paperIds,
       reviewedAt: Timestamp.now(),
       reviewedBy: "hypothesis-critic",
@@ -226,8 +233,8 @@ async function main() {
 
     await logEvent(
       "step" as any,
-      `[${result.verdict.toUpperCase()}] ${h.title.slice(0, 70)}`,
-      result.argument.slice(0, 120)
+      `[${result.verdict.toUpperCase()}] ${(typeof h.title === "string" ? h.title : h.title.de).slice(0, 70)}`,
+      (typeof result.argument === "string" ? result.argument : result.argument.de).slice(0, 120)
     );
 
     // Create research task if needed

--- a/agents/hypothesis-generator.ts
+++ b/agents/hypothesis-generator.ts
@@ -28,10 +28,15 @@ interface Paper {
   publishedAt?: Timestamp;
 }
 
+interface BilingualField {
+  de: string;
+  en: string;
+}
+
 interface Hypothesis {
-  title: string;
-  description: string;
-  rationale: string;
+  title: BilingualField;
+  description: BilingualField;
+  rationale: BilingualField;
   paperIds: string[];
   status: "pending_review";
   generatedAt: Timestamp;
@@ -62,7 +67,7 @@ async function getExistingHypothesisTitles(): Promise<Set<string>> {
 }
 
 async function generateHypotheses(papers: Paper[]): Promise<
-  { title: string; description: string; rationale: string; paperIds: string[] }[]
+  { title: BilingualField; description: BilingualField; rationale: BilingualField; paperIds: string[] }[]
 > {
   const paperSummaries = papers
     .slice(0, 20)
@@ -79,7 +84,8 @@ Analysiere die folgenden ${papers.length} aktuellen Studien und leite daraus ${M
 Anforderungen:
 - Hypothesen müssen NEU und noch NICHT explizit in den Papers bewiesen sein
 - Sie sollen testbare Zusammenhänge zwischen Faktoren beschreiben
-- Formuliere auf Deutsch, klar und präzise
+- Formuliere ALLE Textfelder (title, description, rationale) zweisprachig: Deutsch UND Englisch
+- Jedes Feld ist ein Objekt mit "de" und "en" Schlüssel
 - Beziehe dich konkret auf Paper-Titel als Basis (keine rohen IDs verwenden)
 
 Studien:
@@ -150,8 +156,9 @@ async function main() {
   let saved = 0;
 
   for (const h of hypotheses) {
-    if (existing.has(h.title)) {
-      console.log(`  → Duplicate skipped: ${h.title.slice(0, 60)}`);
+    const titleStr = typeof h.title === "string" ? h.title : h.title.de;
+    if (existing.has(titleStr)) {
+      console.log(`  → Duplicate skipped: ${titleStr.slice(0, 60)}`);
       continue;
     }
     const doc: Hypothesis = {
@@ -164,8 +171,10 @@ async function main() {
       generatedBy: "hypothesis-generator",
     };
     await db.collection("hypotheses").add(doc);
-    await logEvent("step" as any, `Hypothese gespeichert: ${h.title.slice(0, 80)}`, h.description.slice(0, 120));
-    console.log(`  ✓ ${h.title.slice(0, 70)}`);
+    const logTitle = typeof h.title === "string" ? h.title : h.title.de;
+    const logDesc = typeof h.description === "string" ? h.description : h.description.de;
+    await logEvent("step" as any, `Hypothese gespeichert: ${logTitle.slice(0, 80)}`, logDesc.slice(0, 120));
+    console.log(`  ✓ ${logTitle.slice(0, 70)}`);
     saved++;
   }
 

--- a/scripts/migrate-bilingual.ts
+++ b/scripts/migrate-bilingual.ts
@@ -1,0 +1,51 @@
+/**
+ * Migration: Convert existing hypothesis string fields to bilingual { de, en } format.
+ * Old string values become the "de" value; "en" is left empty for future backfill.
+ *
+ * Usage: npx tsx scripts/migrate-bilingual.ts
+ */
+import "dotenv/config";
+import { readFileSync } from "fs";
+import { initializeApp, cert, type ServiceAccount } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+
+const serviceAccount = JSON.parse(
+  process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON ??
+    readFileSync(process.env.GOOGLE_APPLICATION_CREDENTIALS ?? "./firebase-service-account.json", "utf8")
+) as ServiceAccount;
+
+initializeApp({ credential: cert(serviceAccount) });
+const db = getFirestore();
+
+const FIELDS = ["title", "description", "rationale", "criticArgument"] as const;
+
+async function migrate() {
+  const snap = await db.collection("hypotheses").get();
+  console.log(`Found ${snap.size} hypotheses`);
+
+  let migrated = 0;
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    const updates: Record<string, { de: string; en: string }> = {};
+
+    for (const field of FIELDS) {
+      const val = data[field];
+      if (typeof val === "string" && val.length > 0) {
+        updates[field] = { de: val, en: "" };
+      }
+    }
+
+    if (Object.keys(updates).length > 0) {
+      await doc.ref.update(updates);
+      console.log(`  ✓ ${(typeof data.title === "string" ? data.title : data.title?.de ?? doc.id).slice(0, 60)}`);
+      migrated++;
+    }
+  }
+
+  console.log(`\nDone. ${migrated}/${snap.size} hypotheses migrated.`);
+}
+
+migrate().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/lib/hypotheses.ts
+++ b/src/lib/hypotheses.ts
@@ -2,15 +2,17 @@ import { apiFetch } from './api'
 
 export type HypothesisStatus = 'pending_review' | 'open' | 'challenged' | 'needs_research'
 
+export type BilingualField = string | { de: string; en: string }
+
 export interface Hypothesis {
   id: string
-  title: string
-  description: string
-  rationale: string
+  title: BilingualField
+  description: BilingualField
+  rationale: BilingualField
   paperIds: string[]
   status: HypothesisStatus
   generatedAt: string | null
-  criticArgument?: string | null
+  criticArgument?: BilingualField | null
   criticPaperIds?: string[]
   criticPaperTitles?: Record<string, string>
   reviewedAt?: string | null

--- a/src/lib/localized.ts
+++ b/src/lib/localized.ts
@@ -1,0 +1,12 @@
+import i18n from "../i18n";
+
+/**
+ * Extract the localized string from a bilingual field.
+ * Backward-compatible: if the field is a plain string (old data), returns it as-is.
+ */
+export function localized(field: string | { de: string; en: string } | undefined | null): string {
+  if (!field) return "";
+  if (typeof field === "string") return field;
+  const lang = i18n.language as "de" | "en";
+  return field[lang] ?? field.de ?? field.en ?? "";
+}

--- a/src/pages/Hypotheses.tsx
+++ b/src/pages/Hypotheses.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { subscribeHypotheses, formatTs, sanitizeCriticText, type Hypothesis } from '../lib/hypotheses'
+import { localized } from '../lib/localized'
 import { CardListSkeleton } from '../components/Skeleton'
 import EmptyState from '../components/EmptyState'
 
@@ -19,18 +20,18 @@ function HypothesisCard({ h }: { h: Hypothesis }) {
       className="block rounded-xl border border-stone-200 bg-white p-6 transition-shadow hover:shadow-md"
     >
       <div className="flex items-start justify-between gap-4">
-        <h2 className="text-base font-semibold text-stone-900 leading-snug">{h.title}</h2>
+        <h2 className="text-base font-semibold text-stone-900 leading-snug">{localized(h.title)}</h2>
         {cfg && (
           <span className={`shrink-0 rounded-full px-2.5 py-0.5 text-xs font-medium ${cfg.color}`}>
             {cfg.icon} {t(cfg.labelKey)}
           </span>
         )}
       </div>
-      <p className="mt-2 text-sm text-stone-600 line-clamp-3">{h.description}</p>
+      <p className="mt-2 text-sm text-stone-600 line-clamp-3">{localized(h.description)}</p>
       {h.status === 'challenged' && h.criticArgument && (
         <div className="mt-3 rounded-lg bg-red-50 border border-red-100 px-3 py-2 text-xs text-red-700">
           <span className="font-medium"> {t('hypotheses.criticism')}: </span>
-          {sanitizeCriticText(h.criticArgument, h.criticPaperTitles).slice(0, 120)}…
+          {sanitizeCriticText(localized(h.criticArgument), h.criticPaperTitles).slice(0, 120)}…
         </div>
       )}
       <div className="mt-4 flex items-center gap-4 text-xs text-stone-400">

--- a/src/pages/HypothesisDetail.tsx
+++ b/src/pages/HypothesisDetail.tsx
@@ -3,6 +3,7 @@ import { Link, useParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useAuth } from '../contexts/AuthContext'
 import { getHypothesis, getComments, addComment, formatTs, sanitizeCriticText, type Hypothesis, type HypothesisComment } from '../lib/hypotheses'
+import { localized } from '../lib/localized'
 import { DetailSkeleton } from '../components/Skeleton'
 
 const STATUS_CONFIG: Record<string, { labelKey: string; badge: string; icon: string; descKey: string }> = {
@@ -57,7 +58,7 @@ export default function HypothesisDetail() {
       {/* Main card */}
       <article className="mt-6 rounded-xl border border-stone-200 bg-white p-7">
         <div className="flex items-start justify-between gap-4">
-          <h1 className="text-2xl font-bold text-stone-900 leading-snug">{hypo.title}</h1>
+          <h1 className="text-2xl font-bold text-stone-900 leading-snug">{localized(hypo.title)}</h1>
           {cfg && (
             <span className={`shrink-0 rounded-full px-3 py-1 text-sm font-medium ${cfg.badge}`}>
               {cfg.icon} {t(cfg.labelKey)}
@@ -69,11 +70,11 @@ export default function HypothesisDetail() {
            {t('hypotheses.generated_at', { date: formatTs(hypo.generatedAt) })}
         </div>
 
-        <p className="mt-5 text-stone-700 leading-relaxed">{hypo.description}</p>
+        <p className="mt-5 text-stone-700 leading-relaxed">{localized(hypo.description)}</p>
 
         <div className="mt-5 rounded-lg bg-amber-50 border border-amber-100 p-4">
           <p className="text-xs font-semibold uppercase tracking-wide text-amber-700 mb-1">{t('hypotheses.rationale')}</p>
-          <p className="text-sm text-stone-700 leading-relaxed">{hypo.rationale}</p>
+          <p className="text-sm text-stone-700 leading-relaxed">{localized(hypo.rationale)}</p>
         </div>
       </article>
 
@@ -87,7 +88,7 @@ export default function HypothesisDetail() {
           <p className="text-xs font-semibold uppercase tracking-wide text-stone-500 mb-2">
              {t('hypotheses.critic_agent')} — {cfg ? t(cfg.descKey) : ''}
           </p>
-          <p className="text-sm text-stone-700 leading-relaxed">{sanitizeCriticText(hypo.criticArgument, hypo.criticPaperTitles)}</p>
+          <p className="text-sm text-stone-700 leading-relaxed">{sanitizeCriticText(localized(hypo.criticArgument), hypo.criticPaperTitles)}</p>
           {hypo.reviewedAt && (
             <p className="mt-2 text-xs text-stone-400">{t('hypotheses.reviewed_at', { date: formatTs(hypo.reviewedAt) })}</p>
           )}


### PR DESCRIPTION
## Änderungen

- **hypothesis-generator**: Prompt gibt title/description/rationale als `{ de, en }` zurück
- **hypothesis-critic**: criticArgument als `{ de, en }`, Sanitization auf beiden Sprachen
- **Frontend**: `localized()` Helper für sprach-abhängige Anzeige (rückwärtskompatibel mit alten String-Daten)
- **Hypotheses + HypothesisDetail**: Alle Felder über `localized()` aufgelöst
- **Migration Script**: `scripts/migrate-bilingual.ts` konvertiert bestehende String-Felder zu `{ de, en }`

## Rückwärtskompatibilität
`localized()` erkennt alte String-Daten und gibt sie direkt zurück — kein Breaking Change für bestehende Einträge.