### PR TITLE
[Fix] #92: Relative Zeitangaben in Arena respektieren Spracheinstellung

### DIFF
--- a/src/lib/agentArena.test.ts
+++ b/src/lib/agentArena.test.ts
@@ -8,6 +8,9 @@ describe('agent arena helpers', () => {
 
     expect(formatRelative(Timestamp.fromMillis(now - 30_000))).toBe('gerade eben')
     expect(formatRelative(Timestamp.fromMillis(now - 5 * 60_000))).toBe('vor 5 Min')
+    expect(formatRelative(Timestamp.fromMillis(now - 30_000), 'en')).toBe('just now')
+    expect(formatRelative(Timestamp.fromMillis(now - 5 * 60_000), 'en')).toBe('5 min ago')
+    expect(formatRelative(Timestamp.fromMillis(now - 3 * 3600_000), 'en')).toBe('3h ago')
     expect(durationSec(Timestamp.fromMillis(now), Timestamp.fromMillis(now + 65_000))).toBe('1m 5s')
   })
 })

--- a/src/lib/agentArena.ts
+++ b/src/lib/agentArena.ts
@@ -119,14 +119,23 @@ export function subscribeToRuns(cb: (runs: AgentRun[]) => void, _maxItems = 50) 
   return subscribeToArena(({ runs }) => cb(runs), () => {})
 }
 
-export function formatRelative(ts: string | { toDate(): Date } | null): string {
+export function formatRelative(ts: string | { toDate(): Date } | null, locale: string = 'de'): string {
   if (!ts) return '–'
   const date = typeof ts === 'string' ? new Date(ts) : ts.toDate()
   const diff = Date.now() - date.getTime()
-  if (diff < 60000) return 'gerade eben'
-  if (diff < 3600000) return `vor ${Math.floor(diff / 60000)} Min`
-  if (diff < 86400000) return `vor ${Math.floor(diff / 3600000)} Std`
-  return date.toLocaleDateString('de-DE')
+  const lang = locale.startsWith('de') ? 'de' : 'en'
+
+  if (lang === 'de') {
+    if (diff < 60000) return 'gerade eben'
+    if (diff < 3600000) return `vor ${Math.floor(diff / 60000)} Min`
+    if (diff < 86400000) return `vor ${Math.floor(diff / 3600000)} Std`
+    return date.toLocaleDateString('de-DE')
+  }
+
+  if (diff < 60000) return 'just now'
+  if (diff < 3600000) return `${Math.floor(diff / 60000)} min ago`
+  if (diff < 86400000) return `${Math.floor(diff / 3600000)}h ago`
+  return date.toLocaleDateString('en-US')
 }
 
 export function durationSec(start: string | { toDate(): Date } | null, end: string | { toDate(): Date } | null): string {

--- a/src/pages/AgentArena.tsx
+++ b/src/pages/AgentArena.tsx
@@ -65,7 +65,7 @@ const STATUS_LABEL_KEY: Record<string, string> = {
 // ── Agent Status Card ─────────────────────────────────────────────────────────
 
 function AgentCard({ runs }: { runs: AgentRun[] }) {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const lastRun = runs[0]
   if (!lastRun) return null
   const meta = AGENT_META[lastRun.agent] ?? { label: lastRun.agent, emoji: '', color: 'gray' }
@@ -92,7 +92,7 @@ function AgentCard({ runs }: { runs: AgentRun[] }) {
       </div>
       <p className="mt-2 text-xs text-stone-500 line-clamp-2">{lastRun.summary}</p>
       <div className="mt-2 flex items-center justify-between text-xs text-stone-400">
-        <span>{formatRelative(lastRun.startedAt)}</span>
+        <span>{formatRelative(lastRun.startedAt, i18n.language)}</span>
         <span>
           {lastRun.itemsProcessed > 0 && `${lastRun.itemsProcessed} ${t('arena.items')} · `}
           {durationSec(lastRun.startedAt, lastRun.completedAt)}
@@ -105,7 +105,7 @@ function AgentCard({ runs }: { runs: AgentRun[] }) {
 // ── Live Feed Item ────────────────────────────────────────────────────────────
 
 function FeedItem({ event, isNew }: { event: AgentEvent & { repeatCount?: number }; isNew: boolean }) {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const meta = AGENT_META[event.agent] ?? { label: event.agent, emoji: '' }
   const detail = event.detail
     ? (event.type === 'error' && /\{.*"type"\s*:\s*"error"/.test(event.detail))
@@ -123,7 +123,7 @@ function FeedItem({ event, isNew }: { event: AgentEvent & { repeatCount?: number
         <div className="flex items-center gap-2">
           <span className="text-xs font-medium opacity-60">{meta.emoji} {meta.label}</span>
           <span className="ml-auto shrink-0 text-xs opacity-40">
-            {formatRelative(event.timestamp)}
+            {formatRelative(event.timestamp, i18n.language)}
           </span>
         </div>
         <p className="mt-0.5 font-medium leading-snug">{event.message}</p>
@@ -138,7 +138,7 @@ function FeedItem({ event, isNew }: { event: AgentEvent & { repeatCount?: number
 // ── Run History Row (desktop table) ──────────────────────────────────────────
 
 function RunRow({ run }: { run: AgentRun }) {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const meta = AGENT_META[run.agent] ?? { label: run.agent, emoji: '' }
   return (
     <tr className="border-b border-stone-100 hover:bg-stone-50">
@@ -156,7 +156,7 @@ function RunRow({ run }: { run: AgentRun }) {
         {run.itemsProcessed > 0 ? `${run.itemsProcessed} ${t('arena.items')}` : '–'}
       </td>
       <td className="py-2 text-xs text-stone-400 whitespace-nowrap">
-        {formatRelative(run.startedAt)} · {durationSec(run.startedAt, run.completedAt)}
+        {formatRelative(run.startedAt, i18n.language)} · {durationSec(run.startedAt, run.completedAt)}
       </td>
     </tr>
   )
@@ -165,7 +165,7 @@ function RunRow({ run }: { run: AgentRun }) {
 // ── Run History Card (mobile) ────────────────────────────────────────────────
 
 function RunCard({ run }: { run: AgentRun }) {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const meta = AGENT_META[run.agent] ?? { label: run.agent, emoji: '' }
   return (
     <div className="rounded-xl border border-stone-200 bg-white p-4">
@@ -178,7 +178,7 @@ function RunCard({ run }: { run: AgentRun }) {
       {run.summary && <p className="mt-2 text-xs text-stone-500 line-clamp-2">{run.summary}</p>}
       <div className="mt-2 flex items-center justify-between text-xs text-stone-400">
         <span>{run.itemsProcessed > 0 ? `${run.itemsProcessed} ${t('arena.items')}` : '–'}</span>
-        <span>{formatRelative(run.startedAt)} · {durationSec(run.startedAt, run.completedAt)}</span>
+        <span>{formatRelative(run.startedAt, i18n.language)} · {durationSec(run.startedAt, run.completedAt)}</span>
       </div>
     </div>
   )


### PR DESCRIPTION
Fixes #92

## Änderungen
- `formatRelative` akzeptiert jetzt einen `locale`-Parameter (default `'de'`)
- Alle Aufrufe in `AgentArena.tsx` übergeben `i18n.language`
- EN-Strings: "just now", "5 min ago", "3h ago"
- Tests für englische Locale ergänzt

## Test
- `npx tsc -b --noEmit` — keine Fehler
- `npx vitest run src/lib/agentArena.test.ts` — bestanden (DE + EN)
- `npx eslint` — keine Warnings