### PR TITLE
[Fix] #115: Hypothesis Critic crash — h.title.slice is not a function

### DIFF
--- a/agents/hypothesis-critic.ts
+++ b/agents/hypothesis-critic.ts
@@ -291,12 +291,12 @@ async function main() {
 
     for (const doc of defenseSnap.docs) {
       const h = doc.data() as any;
-      const titleStr = typeof h.title === "string" ? h.title : h.title.de;
+      const titleStr = resolveI18n(h.title);
       console.log(`\nReviewing defense: "${titleStr.slice(0, 70)}"`);
 
       try {
         const result = await reviewDefense(
-          { id: doc.id, title: titleStr, description: typeof h.description === "string" ? h.description : h.description.de, rationale: typeof h.rationale === "string" ? h.rationale : h.rationale.de, criticArgument: h.criticArgument, defenseArgument: h.defenseArgument },
+          { id: doc.id, title: titleStr, description: resolveI18n(h.description), rationale: resolveI18n(h.rationale), criticArgument: h.criticArgument ?? { de: "", en: "" }, defenseArgument: h.defenseArgument ?? { de: "", en: "" } },
           defensePapers
         );
 


### PR DESCRIPTION
Fixes #115

## Änderungen
- Ersetze unsichere manuelle Typ-Prüfung (`typeof h.title === 'string' ? h.title : h.title.de`) durch `resolveI18n(h.title)` in der Defense-Review-Phase des Hypothesis Critic
- Gleiches für `h.description` und `h.rationale`
- Defensive Fallbacks für `criticArgument` und `defenseArgument` (nullish coalescing zu leerem BilingualField)

## Ursache
Wenn `h.title` in Firestore `null`, `undefined` oder ein unerwarteter Typ war, crashte der Code mit `h.title.slice is not a function` bzw. `Cannot read properties of null`. Die bestehende Hilfsfunktion `resolveI18n()` behandelt alle Fälle bereits sicher.

## Test
- `npx tsc --noEmit` in `agents/` — keine Fehler