### PR TITLE
[Fix] #114: Sanitize internal error details on Arena page

### DIFF
--- a/src/lib/agentArena.ts
+++ b/src/lib/agentArena.ts
@@ -119,6 +119,23 @@ export function subscribeToRuns(cb: (runs: AgentRun[]) => void, _maxItems = 50) 
   return subscribeToArena(({ runs }) => cb(runs), () => {})
 }
 
+/**
+ * Sanitize agent error messages to prevent leaking internal details
+ * (Firebase console URLs, Firestore index links, project IDs, stack traces).
+ * Returns a generic placeholder when sensitive content is detected.
+ */
+export function sanitizeErrorDetail(text: string | null, fallback: string): string | null {
+  if (!text) return null
+  const sensitive =
+    /console\.firebase\.google\.com/i.test(text) ||
+    /firestore\/indexes/i.test(text) ||
+    /FAILED_PRECONDITION/i.test(text) ||
+    /project\/[a-z0-9-]+\//i.test(text) ||
+    /googleapis\.com/i.test(text) ||
+    /\{.*"type"\s*:\s*"error"/.test(text)
+  return sensitive ? fallback : text
+}
+
 export function formatRelative(ts: string | { toDate(): Date } | null, locale: string = 'de'): string {
   if (!ts) return '–'
   const date = typeof ts === 'string' ? new Date(ts) : ts.toDate()

--- a/src/pages/AgentArena.tsx
+++ b/src/pages/AgentArena.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
+  sanitizeErrorDetail,
   subscribeToArena,
   formatRelative,
   durationSec,
@@ -90,7 +91,7 @@ function AgentCard({ runs }: { runs: AgentRun[] }) {
           </span>
         </div>
       </div>
-      <p className="mt-2 text-xs text-stone-500 line-clamp-2">{lastRun.summary}</p>
+      <p className="mt-2 text-xs text-stone-500 line-clamp-2">{lastRun.status === 'error' ? (sanitizeErrorDetail(lastRun.summary, t('arena.error_unavailable')) ?? lastRun.summary) : lastRun.summary}</p>
       <div className="mt-2 flex items-center justify-between text-xs text-stone-400">
         <span>{formatRelative(lastRun.startedAt, i18n.language)}</span>
         <span>
@@ -107,11 +108,9 @@ function AgentCard({ runs }: { runs: AgentRun[] }) {
 function FeedItem({ event, isNew }: { event: AgentEvent & { repeatCount?: number }; isNew: boolean }) {
   const { t, i18n } = useTranslation()
   const meta = AGENT_META[event.agent] ?? { label: event.agent, emoji: '' }
-  const detail = event.detail
-    ? (event.type === 'error' && /\{.*"type"\s*:\s*"error"/.test(event.detail))
-      ? t('arena.error_unavailable')
-      : event.detail
-    : null
+  const detail = event.type === 'error'
+    ? sanitizeErrorDetail(event.detail, t('arena.error_unavailable'))
+    : event.detail ?? null
   return (
     <div
       className={`flex gap-3 rounded-lg border p-3 text-sm transition-all duration-500 ${
@@ -151,7 +150,7 @@ function RunRow({ run }: { run: AgentRun }) {
           {t(STATUS_LABEL_KEY[run.status])}
         </span>
       </td>
-      <td className="py-2 pr-4 text-xs text-stone-500 max-w-xs truncate">{run.summary}</td>
+      <td className="py-2 pr-4 text-xs text-stone-500 max-w-xs truncate">{run.status === 'error' ? (sanitizeErrorDetail(run.summary, t('arena.error_unavailable')) ?? run.summary) : run.summary}</td>
       <td className="py-2 pr-4 text-xs text-stone-400 whitespace-nowrap">
         {run.itemsProcessed > 0 ? `${run.itemsProcessed} ${t('arena.items')}` : '–'}
       </td>
@@ -175,7 +174,7 @@ function RunCard({ run }: { run: AgentRun }) {
           {t(STATUS_LABEL_KEY[run.status])}
         </span>
       </div>
-      {run.summary && <p className="mt-2 text-xs text-stone-500 line-clamp-2">{run.summary}</p>}
+      {run.summary && <p className="mt-2 text-xs text-stone-500 line-clamp-2">{run.status === 'error' ? (sanitizeErrorDetail(run.summary, t('arena.error_unavailable')) ?? run.summary) : run.summary}</p>}
       <div className="mt-2 flex items-center justify-between text-xs text-stone-400">
         <span>{run.itemsProcessed > 0 ? `${run.itemsProcessed} ${t('arena.items')}` : '–'}</span>
         <span>{formatRelative(run.startedAt, i18n.language)} · {durationSec(run.startedAt, run.completedAt)}</span>


### PR DESCRIPTION
Fixes #114

## Änderungen
- Neue `sanitizeErrorDetail()`-Utility in `agentArena.ts` — erkennt Firebase-Console-URLs, Firestore-Index-Links, `FAILED_PRECONDITION`, Projekt-IDs und googleapis-URLs
- `FeedItem`: Error-Details werden durch generische Meldung ersetzt wenn interne Infos erkannt werden
- `AgentCard`, `RunRow`, `RunCard`: Summary bei Error-Runs wird ebenfalls sanitized
- Bestehende i18n-Keys (`arena.error_unavailable`) für DE/EN werden wiederverwendet

## Test
- `npx tsc -b --noEmit` — keine Fehler
- `npx eslint` — keine Warnings
- Manuell: Error-Events mit Firebase-URLs zeigen jetzt "Temporär nicht verfügbar" statt interner Details