### PR TITLE
[Fix] #118: Add missing Firestore composite indexes for hypothesis agents

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -189,8 +189,7 @@
           "order": "ASCENDING"
         }
       ]
-    }
-    ,
+    },
     {
       "collectionGroup": "meta_studies",
       "queryScope": "COLLECTION",
@@ -215,6 +214,52 @@
         },
         {
           "fieldPath": "status",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "hypotheses",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "defenseRound",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "reviewedAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "hypotheses",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "reviewedAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "hypotheses",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "defendedAt",
           "order": "ASCENDING"
         }
       ]


### PR DESCRIPTION
Fixes #118

## Änderungen
- Added 3 missing Firestore composite indexes to `firestore.indexes.json`:
  - `hypotheses`: `status + defenseRound + reviewedAt (ASC)` — used by hypothesis-generator to query challenged hypotheses needing defense
  - `hypotheses`: `status + reviewedAt (ASC)` — used by hypothesis-generator fallback query for challenged hypotheses
  - `hypotheses`: `status + defendedAt (ASC)` — used by hypothesis-critic to query hypotheses pending defense review

## Ursache
The hypothesis-generator and hypothesis-critic agents query the `hypotheses` collection with compound `where` + `orderBy` clauses that require composite indexes. These indexes were missing from `firestore.indexes.json`, causing `FAILED_PRECONDITION` errors.

## Nächster Schritt
After merging, deploy the indexes:
```bash
npx firebase-tools deploy --only firestore:indexes --project spondylatlas
```

## Test
- Verified all agent queries in `agents/hypothesis-generator.ts` and `agents/hypothesis-critic.ts` now have matching composite indexes