### PR TITLE
[Fix] #120: Sanitize event.message on Arena page

### DIFF
--- a/src/lib/agentArena.ts
+++ b/src/lib/agentArena.ts
@@ -132,7 +132,8 @@ export function sanitizeErrorDetail(text: string | null, fallback: string): stri
     /FAILED_PRECONDITION/i.test(text) ||
     /project\/[a-z0-9-]+\//i.test(text) ||
     /googleapis\.com/i.test(text) ||
-    /\{.*"type"\s*:\s*"error"/.test(text)
+    /\{.*"type"\s*:\s*"error"/.test(text) ||
+    /at\s+\S+\s+\(.*:\d+:\d+\)/.test(text)
   return sensitive ? fallback : text
 }
 

--- a/src/pages/AgentArena.tsx
+++ b/src/pages/AgentArena.tsx
@@ -111,6 +111,9 @@ function FeedItem({ event, isNew }: { event: AgentEvent & { repeatCount?: number
   const detail = event.type === 'error'
     ? sanitizeErrorDetail(event.detail, t('arena.error_unavailable'))
     : event.detail ?? null
+  const message = event.type === 'error'
+    ? (sanitizeErrorDetail(event.message, t('arena.error_unavailable')) ?? event.message)
+    : event.message
   return (
     <div
       className={`flex gap-3 rounded-lg border p-3 text-sm transition-all duration-500 ${
@@ -125,7 +128,7 @@ function FeedItem({ event, isNew }: { event: AgentEvent & { repeatCount?: number
             {formatRelative(event.timestamp, i18n.language)}
           </span>
         </div>
-        <p className="mt-0.5 font-medium leading-snug">{event.message}</p>
+        <p className="mt-0.5 font-medium leading-snug">{message}</p>
         {detail && (
           <p className="mt-0.5 text-xs opacity-60 line-clamp-2">{detail}</p>
         )}


### PR DESCRIPTION
Fixes #120

## Änderungen
- `FeedItem` component now sanitizes `event.message` (not just `event.detail`) for error events, preventing Firebase Console URLs from leaking to public users
- Added stack trace detection pattern to `sanitizeErrorDetail` regex

## Root Cause
PR #117 added sanitization for `event.detail` and `run.summary`, but the `event.message` field in the Live Feed was rendered unsanitized. The FAILED_PRECONDITION error with the Firebase Console URL was coming through `event.message`.

## Test
- `npx tsc -b --noEmit` — clean
- `npx eslint` — clean