### PR TITLE
[Fix] #126: Translate patient summary heading via i18n

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -122,7 +122,8 @@
     "summary": "Zusammenfassung",
     "abstract": "Abstract",
     "paper_not_found": "Studie nicht gefunden.",
-    "paper_count": "{{count}} Studie(n) gefunden"
+    "paper_count": "{{count}} Studie(n) gefunden",
+    "patient_summary": "Zusammenfassung für medizinische Laien"
   },
   "auth": {
     "login_title": "Willkommen zurück",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -122,7 +122,8 @@
     "summary": "Summary",
     "abstract": "Abstract",
     "paper_not_found": "Paper not found.",
-    "paper_count": "{{count}} paper(s) found"
+    "paper_count": "{{count}} paper(s) found",
+    "patient_summary": "Summary for patients"
   },
   "auth": {
     "login_title": "Welcome back",

--- a/src/lib/textUtils.ts
+++ b/src/lib/textUtils.ts
@@ -38,6 +38,18 @@ export function stripAiPromptPrefix(text: string): string {
 }
 
 /**
+ * Strips a leading markdown heading from patient summaries that duplicates
+ * the UI section title (e.g. "## Zusammenfassung für medizinische Laien").
+ * This heading is rendered via i18n instead, so we remove it from the content.
+ */
+export function stripLeadingSummaryHeading(text: string): string {
+  return text.replace(
+    /^#{1,3}\s*(Zusammenfassung\s+für\s+medizinische\s+Laien|Summary\s+for\s+patients)\s*\n+/i,
+    '',
+  )
+}
+
+/**
  * Entfernt grundlegende Markdown-Syntax für reine Textvorschauen.
  * Beispiel: "# Zusammenfassung\n\nText" → "Zusammenfassung Text"
  */

--- a/src/pages/PaperDetail.tsx
+++ b/src/pages/PaperDetail.tsx
@@ -5,7 +5,7 @@ import { doc, getDoc } from 'firebase/firestore'
 import { db } from '../lib/firebase'
 import type { Paper } from '../lib/types'
 import { usePageMeta } from '../hooks/usePageMeta'
-import { decodeHtml, stripAiPromptPrefix } from '../lib/textUtils'
+import { decodeHtml, stripAiPromptPrefix, stripLeadingSummaryHeading } from '../lib/textUtils'
 import { DetailSkeleton } from '../components/Skeleton'
 import MarkdownContent from '../components/MarkdownContent'
 import { localized } from '../lib/localized'
@@ -148,10 +148,12 @@ export default function PaperDetail() {
 
         {(paper.patientSummary || paper.summary) && (
           <section className="mt-8">
-            <h2 className="text-lg font-semibold text-stone-900">{t('research.summary')}</h2>
+            <h2 className="text-lg font-semibold text-stone-900">
+              {paper.patientSummary ? t('research.patient_summary') : t('research.summary')}
+            </h2>
             <MarkdownContent className="mt-2">
               {paper.patientSummary
-                ? localized(paper.patientSummary)
+                ? stripLeadingSummaryHeading(localized(paper.patientSummary))
                 : stripAiPromptPrefix(decodeHtml(paper.summary))}
             </MarkdownContent>
           </section>


### PR DESCRIPTION
Fixes #126

## Änderungen
- Added `research.patient_summary` i18n key (DE: "Zusammenfassung für medizinische Laien", EN: "Summary for patients")
- PaperDetail: Uses translated heading when `patientSummary` field exists instead of generic "Zusammenfassung"/"Summary"
- Added `stripLeadingSummaryHeading()` utility to remove hardcoded German/English heading from Firestore-stored patient summary markdown content
- This ensures the section heading translates correctly when switching languages

## Hinweis
The deeper issue (hypothesis titles stored as plain strings instead of `{de, en}` objects) requires a data migration in Firestore and is out of scope for this PR. This PR addresses the actionable frontend fix suggested in the issue.

## Test
- `npx tsc -b --noEmit` — no errors
- `npx eslint` — clean